### PR TITLE
Add Conditionals via DelegateMulticall

### DIFF
--- a/src/core_scripts/DelegateMulticall.sol
+++ b/src/core_scripts/DelegateMulticall.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.19;
+
+import "../QuarkScript.sol";
+import "../CodeJar.sol";
+
+contract DelegateMulticall is QuarkScript {
+    error InvalidInput();
+    error CallError(uint256 n, address callContract, bytes callData, uint256 callValue, bytes err);
+    error DelegateCallError(uint256 n, bytes callCode, bytes callData, uint256 callValue, bytes err);
+
+    function run(address[] calldata callContracts, bytes[] calldata callCodes, bytes[] calldata callDatas, uint256[] calldata callValues) external onlyRelayer returns (bytes memory) {
+        if (callContracts.length != callDatas.length || callContracts.length != callCodes.length || callContracts.length != callValues.length) {
+            revert InvalidInput();
+        }
+
+        for (uint256 i = 0; i < callContracts.length; i++) {
+            bool isExec;
+            address callContract = callContracts[i];
+            bytes memory callCode = callCodes[i];
+            bool isCallContract = callContract != address(0);
+            bool isCallCode = callCode.length > 0;
+            if (isCallContract == isCallCode) {
+                revert InvalidInput();
+            }
+            bytes memory callData = callDatas[i];
+            uint256 callValue = callValues[i];
+
+            if (isCallCode) {
+                if (callValue != 0) {
+                    revert InvalidInput();
+                }
+                CodeJar codeJar = relayer().codeJar();
+                address codeAddress = codeJar.saveCode(callCode);
+                (bool success, bytes memory returnData) = codeAddress.delegatecall(callData);
+                if (!success) {
+                    revert DelegateCallError(i, callCode, callData, callValue, returnData);
+                }
+            } else {
+                if (callContract == 0x906f4bD1940737091f18247eAa870D928A85b9Ce) { // keccak("tx.origin")[0:20]
+                    callContract = tx.origin;
+                }
+                (bool success, bytes memory returnData) = callContract.call{value: callValue}(callData);
+                if (!success) {
+                    revert CallError(i, callContract, callData, callValue, returnData);
+                }
+            }
+        }
+        return abi.encode(hex"");
+    }
+
+    // Allow unwrapping Ether
+    receive() external payable {}
+}

--- a/test/scripts/DelegateMulticall.t.sol
+++ b/test/scripts/DelegateMulticall.t.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+
+import "../lib/YulHelper.sol";
+import "../lib/Counter.sol";
+
+import "../../src/core_scripts/DelegateMulticall.sol";
+import "../../src/CodeJar.sol";
+import "../../src/Relayer.sol";
+import "../../src/RelayerAtomic.sol";
+
+contract RunThrice is QuarkScript {
+    error EnoughAlready(uint256 max);
+
+    string constant countVar = "quark.org.RunThrice.count";
+
+    function runCheck(uint256 max) external {
+        uint256 count = sloadU256(countVar);
+        if (count >= max) {
+          revert EnoughAlready(max);
+        }
+
+        sstoreU256(countVar, count + 1);
+    }
+}
+
+contract DelegateMulticallTest is Test {
+    Relayer public relayerAtomic;
+    Counter public counter;
+    CodeJar public codeJar;
+
+    constructor() {
+        codeJar = new CodeJar();
+        console.log("CodeJar deployed to: %s", address(codeJar));
+
+        relayerAtomic = new RelayerAtomic(codeJar);
+        console.log("Relayer kafka deployed to: %s", address(relayerAtomic));
+
+        counter = new Counter();
+        counter.setNumber(0);
+        console.log("Counter deployed to: %s", address(counter));
+    }
+
+    function setUp() public {
+        // nothing
+    }
+
+    function testAtomicDelegateMulticallCounter() public {
+        bytes memory multicallScript = new YulHelper().getDeployed("DelegateMulticall.sol/DelegateMulticall.json");
+        address[] memory callContracts = new address[](2);
+        bytes[] memory callCodes = new bytes[](2);
+        bytes[] memory callDatas = new bytes[](2);
+        uint256[] memory callValues = new uint256[](2);
+        callContracts[0] = address(0);
+        callCodes[0] = type(RunThrice).runtimeCode;
+        callDatas[0] = abi.encodeCall(RunThrice.runCheck, (3));
+        callValues[0] = 0 wei;
+        callContracts[1] = address(counter);
+        callCodes[1] = hex"";
+        callDatas[1] = abi.encodeCall(Counter.incrementBy, (20));
+        callValues[1] = 0 wei;
+        bytes memory multicallInvocation = abi.encodeCall(DelegateMulticall.run, (
+            callContracts,
+            callCodes,
+            callDatas,
+            callValues
+        ));
+
+        assertEq(counter.number(), 0);
+
+        vm.prank(address(0xaa));
+        relayerAtomic.runQuark(multicallScript, multicallInvocation);
+        assertEq(counter.number(), 20);
+
+        vm.prank(address(0xaa));
+        relayerAtomic.runQuark(multicallScript, multicallInvocation);
+        assertEq(counter.number(), 40);
+
+        vm.prank(address(0xaa));
+        relayerAtomic.runQuark(multicallScript, multicallInvocation);
+        assertEq(counter.number(), 60);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                RelayerAtomic.QuarkCallFailed.selector,
+                relayerAtomic.getQuarkAddress(address(0xaa)),
+                abi.encodeWithSelector(DelegateMulticall.DelegateCallError.selector, 0, callCodes[0], callDatas[0], callValues[0],
+                    abi.encodeWithSelector(RunThrice.EnoughAlready.selector, 3)
+                )
+        ));
+
+        vm.prank(address(0xaa));
+        relayerAtomic.runQuark(multicallScript, multicallInvocation);
+        assertEq(counter.number(), 60);
+    }
+}


### PR DESCRIPTION
This patch simply adds a new Quark Script (which are just helpers that don't need to be in the core, but they are since it's nice to expect them to already be deployed). This one allows you to specify that certain code gets "delegatecalled" (as opposed to .call'd) and thus will run on your account. These can be used as conditionals (e.g. check the day of the week or make sure this only runs X times per day or whatever). We currently use `.delegatecall`, though it's possible that we'd want .call or .callstatic, -- open questions here! But I'll apply this going forward to allow complex interactions at the app layer.