### PR TITLE
add readQuarkCodeAddress required by Quark.yul to abstract Relayer

### DIFF
--- a/src/Relayer.sol
+++ b/src/Relayer.sol
@@ -159,6 +159,13 @@ abstract contract Relayer {
     function getQuarkInitCode() public virtual pure returns (bytes memory);
 
     /**
+     * @notice Returns the code associated with a running quark for `msg.sender`
+     * @dev This is generally expected to be used only by the Quark wallet itself
+     *      in the constructor phase to get its code.
+     */
+    function readQuarkCodeAddress() external virtual view returns (address);
+
+    /**
      * Run a quark script from a given account. Note: can also use fallback, which is
      * an alias to this function.
      */

--- a/src/RelayerAtomic.sol
+++ b/src/RelayerAtomic.sol
@@ -60,7 +60,7 @@ contract RelayerAtomic is Relayer {
      * @dev This is generally expected to be used only by the Quark wallet itself
      *      in the constructor phase to get its code.
      */
-    function readQuarkCodeAddress() external view returns (address) {
+    function readQuarkCodeAddress() override external view returns (address) {
         address quarkAddress = msg.sender;
         address quarkCodeAddress = quarkCodes[quarkAddress];
         if (quarkCodeAddress == address(0)) {

--- a/src/RelayerKafka.sol
+++ b/src/RelayerKafka.sol
@@ -65,7 +65,7 @@ contract RelayerKafka is Relayer {
      * @dev This is generally expected to be used only by the Quark wallet itself
      *      in the constructor phase to get its code.
      */
-    function readQuarkCodeAddress() external view returns (address) {
+    function readQuarkCodeAddress() override external view returns (address) {
         address quarkAddress = msg.sender;
         address quarkCodeAddress = quarkCodes[quarkAddress];
         if (quarkCodeAddress == address(0)) {


### PR DESCRIPTION
Learning and walking through the code, and noted that `Quark.yul` requires `readQuarkCodeAddress()` to be implemented