### PR TITLE
[WIP] Code Jar Simplifications

### DIFF
--- a/src/CodeJar.sol
+++ b/src/CodeJar.sol
@@ -2,8 +2,6 @@
 pragma solidity ^0.8.19;
 
 contract CodeJar {
-    error CodeSaveFailed(bytes initCode);
-    error CodeSaveMismatch(bytes initCode, bytes code, address expected, address created);
     error CodeTooLarge(uint256 sz);
     error CodeNotFound(address codeAddress);
 
@@ -13,25 +11,30 @@ contract CodeJar {
      * @return The address of the contract that matches the inputted code.
      */
     function saveCode(bytes calldata code) external returns (address) {
-        (address codeAddress, uint256 codeAddressLen, bytes memory initCode, uint256 initCodeLen) = getInitCode(code);
+        bytes memory initCode = getInitCode(code);
+        address codeAddress = getCodeAddress(initCode);
 
-        if (codeAddressLen == 0) {
+        // Note: we could check without codehash which costs extra gas, but
+        //       the additional check to make sure the code hash matches expectation
+        //       seems valuable.
+        if (codeAddress.codehash == keccak256(code)) {
+            // Code is already deployed and matches expected code
+            return codeAddress;
+        } else {
+            // Note: this branch technically could be triggered if there were ever invalid code
+            //       at the script address (i.e. it didn't match the input code).
             address codeCreateAddress;
+            uint256 initCodeLen = initCode.length;
             assembly {
                 codeCreateAddress := create2(0, add(initCode, 32), initCodeLen, 0)
             }
 
-            // Ensure that the wallet was created.
-            if (uint160(address(codeCreateAddress)) == 0) {
-                revert CodeSaveFailed(initCode);
-            }
+            // Posit: these cannot fail and are purely defense-in-depth
+            require(codeCreateAddress != address(0));
+            require(codeCreateAddress == codeAddress);
 
-            if (codeCreateAddress != codeAddress) {
-                revert CodeSaveMismatch(initCode, code, codeAddress, codeCreateAddress);
-            }
+            return codeAddress;
         }
-
-        return codeAddress;
     }
 
     /**
@@ -39,15 +42,25 @@ contract CodeJar {
      * @return True if code already exists in code jar
      */
     function codeExists(bytes calldata code) external returns (bool) {
-        (address codeAddress, uint256 codeAddressLen, bytes memory initCode, uint256 initCodeLen) = getInitCode(code);
+        bytes memory initCode = getInitCode(code);
+        address codeAddress = getCodeAddress(initCode);
 
-        return codeAddressLen > 0;
+        return codeAddress.codehash == keccak256(code);
     }
 
-    // Helper to get the init code and check if the code exists already.
-    function getInitCode(bytes memory code) internal returns (address, uint256, bytes memory, uint256) {
-        bytes memory initCode = abi.encodePacked(hex"63", uint32(code.length), hex"80600e6000396000f3", code);
-        address codeAddress = address(uint160(uint(
+    function getInitCode(bytes memory code) internal returns (bytes memory) {
+        // Note: The gas cost in memory is `O(a^2)`, thus for an array to be more than 2^32 bytes long, the gas cost
+        //       would be (2^32)^2 or about 13 orders of magnitude above the current block gas limit. As such,
+        //       we rely on check the conversion, but understand it is not possible to accept a value
+        //       whose length would not actually fit in 32 bits.
+        require(code.length <= type(uint32).max);
+        uint32 codeLen = uint32(code.length);
+        
+        return abi.encodePacked(hex"63", codeLen, hex"80600e6000396000f3", code);
+    }
+
+    function getCodeAddress(bytes memory initCode) internal returns (address) {
+        return address(uint160(uint(
             keccak256(
                 abi.encodePacked(
                     bytes1(0xff),
@@ -57,13 +70,6 @@ contract CodeJar {
                 )
             )))
         );
-
-        uint256 codeAddressLen;
-        assembly {
-            codeAddressLen := extcodesize(codeAddress)
-        }
-
-        return (codeAddress, codeAddressLen, initCode, initCode.length);
     }
 
     /**
@@ -78,6 +84,7 @@ contract CodeJar {
             codeLen := extcodesize(codeAddress)
         }
 
+        // TODO: the hex"" empty byte string would incorrectly fail here.
         if (codeLen == 0) {
             revert CodeNotFound(codeAddress);
         }

--- a/test/CodeJar.t.sol
+++ b/test/CodeJar.t.sol
@@ -86,5 +86,12 @@ contract CodeJarTest is Test {
         assertEq(scriptAddress.code, hex"5fff");
     }
 
+    function testCodeJarTooLarge() public {
+        // TODO: Consider how to handle this since we run in a transaction and thus can't self destruct
+        bytes32[] memory script = new bytes32[](1000); // 2**32 / 32 + 1
+        bytes memory code = abi.encodePacked(script);
+        address scriptAddress = codeJar.saveCode(code);
+    }
+
     // TODO: Test code too large (overflow)
 }


### PR DESCRIPTION
This patchs starts to simplify a few things in CodeJar. Specifically, we aim to clean up longer functions into shorter ones, and start to reason about pretty outsized risks (e.g. trying to save a contract that's longer than 2^32 bytes long!). As such, we add a few superfluous checks to make sure there's little risk even in these corner cases. Additionally, we check `codehash` to handle a case where a script somehow gets incorrectly saved at an address (to prevent getting duped into running the wrong code on your account). We also change internal functions thatreturn `(lots, of values)` into multiple simpler functions. The last thing to do here will be to change the external function names (e.g. just `save()` or such) and decide is `read()` should be removed.