### PR TITLE
Clear callback to save gas

### DIFF
--- a/src/QuarkWallet.sol
+++ b/src/QuarkWallet.sol
@@ -274,6 +274,7 @@ contract QuarkWallet is IERC1271 {
                     revert(add(result, 0x20), size)
                 }
             }
+            stateManager.write(CALLBACK_KEY, bytes32(0));
             return result;
         } else {
             revert NoActiveCallback();


### PR DESCRIPTION
An experimental PR to see if setting the callback slot back to 0 after the callback is done saves gas. Indeed, it does, but at the expense of higher deployment costs. Here are the relevant gas diffs:

Tests with callbacks see some gas savings:
```
testCallbackFromCounter() (gas: -8269 (-7.840%)) 
testAllowNestedCallbacks() (gas: -17345 (-11.498%))
```

Tests that deploy wallets see higher wallet deployment costs:
```
testCreateRevertsOnRepeat() (gas: 980 (0.000%)) 
testCreateAdditionalWalletWithSalt() (gas: 33411 (0.000%)) 
testCreateAndExecuteCreatesWallet() (gas: 32410 (2.464%)) 
testExecuteOnExistingWallet() (gas: 32397 (2.466%)) 
testCreateAndExecuteWithSalt() (gas: 34703 (2.479%)) 
testCreateAndExecuteSetsMsgSenderAndValue() (gas: 31553 (2.672%)) 
testCreateAndExecuteWithSaltSetsMsgSenderAndValue() (gas: 32938 (2.678%)) 
testCreatesWalletAtDeterministicAddress() (gas: 65713 (3.027%)) 
testDefaultWalletHasNoExecutor() (gas: 31115 (3.048%)) 
```