### PR TITLE
Nonce clean-up

### DIFF
--- a/src/QuarkStateManager.sol
+++ b/src/QuarkStateManager.sol
@@ -114,14 +114,14 @@ contract QuarkStateManager {
     function setNonce(uint96 nonce) external {
         // TODO: should we check whether there exists a nonceScriptAddress?
         (uint256 bucket, uint256 setMask) = getBucket(nonce);
-        setNonceInternal(msg.sender, bucket, setMask);
+        setNonceInternal(bucket, setMask);
     }
 
     /**
-     * @dev Set a nonce for a wallet, using the nonce's bucket and mask
+     * @dev Set a nonce for the msg.sender, using the nonce's bucket and mask
      */
-    function setNonceInternal(address wallet, uint256 bucket, uint256 setMask) internal {
-        nonces[wallet][bucket] |= setMask;
+    function setNonceInternal(uint256 bucket, uint256 setMask) internal {
+        nonces[msg.sender][bucket] |= setMask;
     }
 
     /**
@@ -149,7 +149,7 @@ contract QuarkStateManager {
         }
 
         // spend the nonce; only if the callee chooses to clear it will it get un-set and become replayable
-        setNonceInternal(msg.sender, bucket, setMask);
+        setNonceInternal(bucket, setMask);
 
         // if the nonce has been used before, check if the script address matches, and revert if not
         if (


### PR DESCRIPTION
This PR includes a few clean-up changes to nonces in the `QuarkStateManager`:

- Remove `getActiveNonce()` since it is not currently used by any Quark contracts or scripts
- Declare `nonceScriptAddress` as public so one can use it to determine the replayability of nonces
- Define internal helpers (`isNonceSetInternal`, `setNonceInternal`) to abstract away any direct operations on nonces