### PR TITLE
Add Out Of Memory Test

### DIFF
--- a/test/Reverts.t.sol
+++ b/test/Reverts.t.sol
@@ -106,4 +106,20 @@ contract RevertsTest is Test {
         vm.expectRevert();
         aliceWallet.executeQuarkOperation(op, v, r, s);
     }
+
+    function testRevertsOutOfMemory() public {
+        // gas: do not meter set-up
+        vm.pauseGasMetering();
+        bytes memory revertsCode = new YulHelper().getDeployed("Reverts.sol/Reverts.json");
+        QuarkWallet.QuarkOperation memory op = new QuarkOperationHelper().newBasicOpWithCalldata(
+            aliceWallet, revertsCode, abi.encodeWithSelector(Reverts.outOfMemory.selector), ScriptType.ScriptAddress
+        );
+        (uint8 v, bytes32 r, bytes32 s) = new SignatureHelper().signOp(alicePrivateKey, aliceWallet, op);
+
+        // gas: meter execute
+        vm.resumeGasMetering();
+        // Reverts with "EvmError: MemoryLimitOOG"
+        vm.expectRevert();
+        aliceWallet.executeQuarkOperation(op, v, r, s);
+    }
 }

--- a/test/lib/Reverts.sol
+++ b/test/lib/Reverts.sol
@@ -37,6 +37,12 @@ contract Reverts {
         }
     }
 
+    function outOfMemory() external {
+        assembly {
+            mstore(0xffffffff, 1)
+        }
+    }
+
     fallback() external {
         revert Whoops();
     }


### PR DESCRIPTION
This test looks to be failing with "MemoryLimitOOG," which seems like it's out of gas based on the memory limit, which seems about as close to the solution here as we're going to get. Since Forge isn't exactly the true EVM, there will always be minor discrepencies, but that's making direct reference to the memory limit.

You can see the exact error code with:

```sh
forge test --match-test "testRevertsOutOfMemory" -vvvv
```