### PR TITLE
Add reentrancy guard modifier to QuarkScript

### DIFF
--- a/src/QuarkScript.sol
+++ b/src/QuarkScript.sol
@@ -9,6 +9,22 @@ import "./QuarkWallet.sol";
  * @author Compound Labs, Inc.
  */
 contract QuarkScript {
+    error ReentrantCall();
+
+    /// @notice storage location for the re-entrancy guard
+    bytes32 internal constant REENTRANCY_FLAG = keccak256("quark.scripts.reentrancy.guard.v1");
+
+    modifier nonReentrant() {
+        if (read(REENTRANCY_FLAG) == bytes32(uint256(1))) {
+            revert ReentrantCall();
+        }
+        write(REENTRANCY_FLAG, bytes32(uint256(1)));
+
+        _;
+
+        write(REENTRANCY_FLAG, bytes32(uint256(0)));
+    }
+
     function allowCallback() internal {
         QuarkWallet self = QuarkWallet(payable(address(this)));
         self.stateManager().write(self.CALLBACK_KEY(), bytes32(uint256(uint160(self.stateManager().getActiveScript()))));

--- a/src/terminal_scripts/TerminalScript.sol
+++ b/src/terminal_scripts/TerminalScript.sol
@@ -175,10 +175,6 @@ contract TransferActions is QuarkScript {
     using SafeERC20 for IERC20;
 
     error TransferFailed(bytes data);
-    error ReentrantCall();
-
-    /// @notice storage location for the re-entrancy guard
-    bytes32 public constant REENTRANCY_FLAG = keccak256("terminal.scripts.reentrancy.guard.v1");
 
     /**
      * @notice Transfer ERC20 token
@@ -195,16 +191,11 @@ contract TransferActions is QuarkScript {
      * @param recipient The recipient address
      * @param amount The amount to transfer
      */
-    function transferNativeToken(address recipient, uint256 amount) external {
-        if (read(REENTRANCY_FLAG) == bytes32(uint256(1))) {
-            revert ReentrantCall();
-        }
-        write(REENTRANCY_FLAG, bytes32(uint256(1)));
+    function transferNativeToken(address recipient, uint256 amount) external nonReentrant {
         (bool success, bytes memory data) = payable(recipient).call{value: amount}("");
         if (!success) {
             revert TransferFailed(data);
         }
-        write(REENTRANCY_FLAG, bytes32(uint256(0)));
     }
 }
 

--- a/test/lib/AllowCallbacks.sol
+++ b/test/lib/AllowCallbacks.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.19;
+
+import "../../src/QuarkWallet.sol";
+
+contract AllowCallbacks {
+    function run(address callbackAddress) public {
+        QuarkWallet self = QuarkWallet(payable(address(this)));
+        self.stateManager().write(self.CALLBACK_KEY(), bytes32(uint256(uint160(callbackAddress))));
+    }
+}

--- a/test/lib/ReentrantTransfer.sol
+++ b/test/lib/ReentrantTransfer.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.19;
+
+contract ReentrantTransfer {
+    error TransferFailed(bytes data);
+
+    /**
+     * @notice Transfer native token (i.e. ETH) without re-entrancy guards
+     * @param recipient The recipient address
+     * @param amount The amount to transfer
+     */
+    function transferNativeToken(address recipient, uint256 amount) external {
+        // Transfer without using re-entrancy guards
+        (bool success, bytes memory data) = payable(recipient).call{value: amount}("");
+        if (!success) {
+            revert TransferFailed(data);
+        }
+    }
+}


### PR DESCRIPTION
This introduces a `nonReentrant` modifier to `QuarkScript` that can be used by other scripts. We also improve our test coverage of reentrancy attacks by constructing a case of a successful attack that can occur when callback is enabled and the transfer is not protected by a reentrancy guard. We previously did not have a happy path of the attack since we didn't have callbacks enabled.