### PR TITLE
hack: use public getter for immutable instead of passing it down

### DIFF
--- a/script/Debug.s.sol
+++ b/script/Debug.s.sol
@@ -21,7 +21,9 @@ contract Debug is Script {
         Proxy proxy = new Proxy(address(impl), dummy, address(0), codejar, manager);
         (bool success, bytes memory result) = address(proxy).call(abi.encodeWithSignature("getSigner()"));
         if (!success) {
-            assembly { revert(add(result, 0x20), mload(result)) }
+            assembly {
+                revert(add(result, 0x20), mload(result))
+            }
         }
         address signer = abi.decode(result, (address));
         console.log(signer);

--- a/src/Proxy.sol
+++ b/src/Proxy.sol
@@ -21,7 +21,13 @@ contract Proxy {
      * @param codeJar_ The CodeJar contract used to deploy scripts
      * @param stateManager_ The QuarkStateManager contract used to write/read nonces and storage for this wallet
      */
-    constructor(address implementation_, address signer_, address executor_, CodeJar codeJar_, QuarkStateManager stateManager_) {
+    constructor(
+        address implementation_,
+        address signer_,
+        address executor_,
+        CodeJar codeJar_,
+        QuarkStateManager stateManager_
+    ) {
         signer = signer_;
         executor = executor_;
         walletImplementation = implementation_;

--- a/src/QuarkWallet.sol
+++ b/src/QuarkWallet.sol
@@ -110,7 +110,7 @@ contract QuarkWallet is IERC1271 {
      * crazy stuff
      */
     function getSigner() public returns (address) {
-        (,bytes memory result) = address(this).call(abi.encodeWithSignature("signer()"));
+        (, bytes memory result) = address(this).call(abi.encodeWithSignature("signer()"));
         return abi.decode(result, (address));
     }
 


### PR DESCRIPTION
```
forge script script/Debug.s.sol
```

seems to do the thing, and it's not the _worst_