### PR TITLE
Change UniswapFactoryAddress library into an abstract contract to avoid inlining

### DIFF
--- a/quark-core-scripts/src/UniswapFlashLoan.sol
+++ b/quark-core-scripts/src/UniswapFlashLoan.sol
@@ -10,7 +10,7 @@ import "quark-core/src/QuarkScript.sol";
 import "quark-core-scripts/src/vendor/uniswap_v3_periphery/PoolAddress.sol";
 import "quark-core-scripts/src/lib/UniswapFactoryAddress.sol";
 
-contract UniswapFlashLoan is IUniswapV3FlashCallback, QuarkScript {
+contract UniswapFlashLoan is IUniswapV3FlashCallback, UniswapFactoryAddress, QuarkScript {
     using SafeERC20 for IERC20;
 
     error InvalidCaller();
@@ -48,7 +48,7 @@ contract UniswapFlashLoan is IUniswapV3FlashCallback, QuarkScript {
         }
         IUniswapV3Pool(
             PoolAddress.computeAddress(
-                UniswapFactoryAddress.getAddress(), PoolAddress.getPoolKey(payload.token0, payload.token1, payload.fee)
+                getUniswapFactoryAddress(), PoolAddress.getPoolKey(payload.token0, payload.token1, payload.fee)
             )
         ).flash(
             address(this),
@@ -75,7 +75,7 @@ contract UniswapFlashLoan is IUniswapV3FlashCallback, QuarkScript {
     function uniswapV3FlashCallback(uint256 fee0, uint256 fee1, bytes calldata data) external {
         FlashLoanCallbackPayload memory input = abi.decode(data, (FlashLoanCallbackPayload));
         IUniswapV3Pool pool =
-            IUniswapV3Pool(PoolAddress.computeAddress(UniswapFactoryAddress.getAddress(), input.poolKey));
+            IUniswapV3Pool(PoolAddress.computeAddress(getUniswapFactoryAddress(), input.poolKey));
         if (msg.sender != address(pool)) {
             revert InvalidCaller();
         }

--- a/quark-core-scripts/src/UniswapFlashSwapExactOut.sol
+++ b/quark-core-scripts/src/UniswapFlashSwapExactOut.sol
@@ -11,7 +11,7 @@ import "quark-core/src/QuarkScript.sol";
 import "quark-core-scripts/src/vendor/uniswap_v3_periphery/PoolAddress.sol";
 import "quark-core-scripts/src/lib/UniswapFactoryAddress.sol";
 
-contract UniswapFlashSwapExactOut is IUniswapV3SwapCallback, QuarkScript {
+contract UniswapFlashSwapExactOut is IUniswapV3SwapCallback, UniswapFactoryAddress, QuarkScript {
     using SafeERC20 for IERC20;
     using SafeCast for uint256;
 
@@ -50,7 +50,7 @@ contract UniswapFlashSwapExactOut is IUniswapV3SwapCallback, QuarkScript {
         allowCallback();
         bool zeroForOne = payload.tokenIn < payload.tokenOut;
         PoolAddress.PoolKey memory poolKey = PoolAddress.getPoolKey(payload.tokenIn, payload.tokenOut, payload.fee);
-        IUniswapV3Pool(PoolAddress.computeAddress(UniswapFactoryAddress.getAddress(), poolKey)).swap(
+        IUniswapV3Pool(PoolAddress.computeAddress(getUniswapFactoryAddress(), poolKey)).swap(
             address(this),
             zeroForOne,
             -payload.amountOut.toInt256(),
@@ -76,7 +76,7 @@ contract UniswapFlashSwapExactOut is IUniswapV3SwapCallback, QuarkScript {
     function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata data) external {
         FlashSwapExactOutInput memory input = abi.decode(data, (FlashSwapExactOutInput));
         IUniswapV3Pool pool =
-            IUniswapV3Pool(PoolAddress.computeAddress(UniswapFactoryAddress.getAddress(), input.poolKey));
+            IUniswapV3Pool(PoolAddress.computeAddress(getUniswapFactoryAddress(), input.poolKey));
         if (msg.sender != address(pool)) {
             revert InvalidCaller();
         }

--- a/quark-core-scripts/src/lib/UniswapFactoryAddress.sol
+++ b/quark-core-scripts/src/lib/UniswapFactoryAddress.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity 0.8.19;
 
-library UniswapFactoryAddress {
+abstract contract UniswapFactoryAddress {
     // Reference: https://docs.uniswap.org/contracts/v3/reference/deployments
     address internal constant MAINNET = 0x1F98431c8aD98523631AE4a59f267346ea31F984;
     address internal constant CELO = 0xAfE208a311B21f13EF87E33A90049fC17A7acDEc;
@@ -10,7 +10,7 @@ library UniswapFactoryAddress {
 
     error UnrecognizedChain(uint256);
 
-    function getAddress() internal view returns (address) {
+    function getUniswapFactoryAddress() internal view returns (address) {
         if (block.chainid == 1) return MAINNET; // Ethereum mainnet
         if (block.chainid == 10) return MAINNET; // Optimism mainnet
         if (block.chainid == 42161) return MAINNET; // Arbitrum mainnet


### PR DESCRIPTION
~~This should help to reduce the bytecode size of scripts using this dependency.~~

EDIT: Actually, after comparing the contract sizes compiled with --via-ir, looks like there's no difference in bytecode size. The gas diffs also show no differences. 