### PR TITLE
Test edge case where cached script address differs from the Quark Operation script address

### DIFF
--- a/test/lib/CallOtherScript.sol
+++ b/test/lib/CallOtherScript.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.23;
+
+import "quark-core/src/QuarkScript.sol";
+import "quark-core/src/QuarkWallet.sol";
+
+contract CallOtherScript is QuarkScript {
+    function call(uint96 nonce, address scriptAddress, bytes calldata scriptCalldata) public {
+        // Anti-pattern to clear replay first, but this is necessary to hit our edge case
+        allowReplay();
+        QuarkWallet(payable(address(this))).stateManager().setActiveNonceAndCallback(
+            nonce, scriptAddress, scriptCalldata
+        );
+        QuarkWallet(payable(address(this))).stateManager().setNonce(nonce);
+    }
+}


### PR DESCRIPTION
Weird edge-case that seems benign and scripts really have to go out of their way to achieve this. The right way to fix this is to cache the `scriptAddress` before calling `executeScriptWithNonceLock`, but that adds a ~15k gas overhead. Consider our implementation a conscious optimization at this point.