### PR TITLE
Update GAS_OVERHEAD constant in Paycall and Quotecall

### DIFF
--- a/src/quark-core-scripts/src/Paycall.sol
+++ b/src/quark-core-scripts/src/Paycall.sol
@@ -35,8 +35,8 @@ contract Paycall {
     uint256 internal immutable divisorScale;
 
     /// @notice Constant buffer for gas overhead
-    /// This is a constant to account for the gas used by the Paycall contract itself that's not tracked by gasleft()
-    uint256 internal constant GAS_OVERHEAD = 75000;
+    /// This is a constant to account for the gas used by a Quark operation that is not tracked by the Paycall contract itself
+    uint256 internal constant GAS_OVERHEAD = 67_500;
 
     /// @dev The number of decimals for the chain's native token
     uint256 internal constant NATIVE_TOKEN_DECIMALS = 18;

--- a/src/quark-core-scripts/src/Quotecall.sol
+++ b/src/quark-core-scripts/src/Quotecall.sol
@@ -38,8 +38,8 @@ contract Quotecall {
     uint256 internal immutable divisorScale;
 
     /// @notice Constant buffer for gas overhead
-    /// This is a constant to accounted for the gas used by the Quotecall contract itself that's not tracked by gasleft()
-    uint256 internal constant GAS_OVERHEAD = 75000;
+    /// This is a constant to account for the gas used by a Quark operation that is not tracked by the Quotecall contract itself
+    uint256 internal constant GAS_OVERHEAD = 67_500;
 
     /// @dev The scale for percentages, used for `maxDeltaPercentage` (e.g. 1e18 = 100%)
     uint256 internal constant PERCENTAGE_SCALE = 1e18;

--- a/test/quark-core-scripts/Paycall.t.sol
+++ b/test/quark-core-scripts/Paycall.t.sol
@@ -180,11 +180,11 @@ contract PaycallTest is Test {
         // gas: meter execute
         vm.resumeGasMetering();
         vm.expectEmit(true, true, true, false); // We ignore the amount because it will differ based on via-IR
-        emit PayForGas(address(wallet), tx.origin, USDC, 7_264_471);
+        emit PayForGas(address(wallet), tx.origin, USDC, 6_792_365);
         wallet.executeQuarkOperation(op, v, r, s);
 
         assertEq(counter.number(), 15);
-        assertApproxEqAbs(IERC20(USDC).balanceOf(address(wallet)), 992e6, 1e6);
+        assertApproxEqAbs(IERC20(USDC).balanceOf(address(wallet)), 993e6, 1e6);
     }
 
     function testSimpleTransferTokenAndPayWithUSDC() public {
@@ -278,10 +278,10 @@ contract PaycallTest is Test {
         // gas: meter execute
         vm.resumeGasMetering();
         vm.expectEmit(true, true, true, false); // We ignore the amount because it will differ based on via-IR
-        emit PayForGas(address(wallet), tx.origin, USDC, 18_045_902);
+        emit PayForGas(address(wallet), tx.origin, USDC, 17_584_109);
         wallet.executeQuarkOperation(op, v, r, s);
 
-        assertApproxEqAbs(IERC20(USDC).balanceOf(address(wallet)), 981e6, 1e6);
+        assertApproxEqAbs(IERC20(USDC).balanceOf(address(wallet)), 982e6, 1e6);
         assertEq(IComet(cUSDCv3).collateralBalanceOf(address(wallet), WETH), 100 ether);
         assertApproxEqAbs(IComet(cUSDCv3).borrowBalanceOf(address(wallet)), 1000e6, 2);
     }
@@ -350,12 +350,12 @@ contract PaycallTest is Test {
 
         vm.resumeGasMetering();
         vm.expectEmit(true, true, true, false); // We ignore the amount because it will differ based on via-IR
-        emit PayForGas(address(wallet), tx.origin, USDT, 7_056_836);
+        emit PayForGas(address(wallet), tx.origin, USDT, 6_622_373);
         wallet.executeQuarkOperation(op, v, r, s);
 
         assertEq(IERC20(WETH).balanceOf(address(this)), 1 ether);
         // About $8 in USD fees
-        assertApproxEqAbs(IERC20(USDT).balanceOf(address(wallet)), 992e6, 1e6);
+        assertApproxEqAbs(IERC20(USDT).balanceOf(address(wallet)), 993e6, 1e6);
     }
 
     function testPaycallForPayWithWBTC() public {
@@ -388,12 +388,12 @@ contract PaycallTest is Test {
 
         vm.resumeGasMetering();
         vm.expectEmit(true, true, true, false); // We ignore the amount because it will differ based on via-IR
-        emit PayForGas(address(wallet), tx.origin, WBTC, 20_332);
+        emit PayForGas(address(wallet), tx.origin, WBTC, 19_079);
         wallet.executeQuarkOperation(op, v, r, s);
 
         assertEq(IERC20(WETH).balanceOf(address(this)), 1 ether);
         // Fees in WBTC will be around ~ 0.00021 WBTC
-        assertApproxEqAbs(IERC20(WBTC).balanceOf(address(wallet)), 99_979_000, 1e3);
+        assertApproxEqAbs(IERC20(WBTC).balanceOf(address(wallet)), 99_981_000, 1e3);
     }
 
     function testRevertsWhenCostIsMoreThanMaxPaymentCost() public {


### PR DESCRIPTION
The current `GAS_OVERHEAD` slightly overestimates the amount. After running some gas tracing experiments in foundry, the rough range of gas used outside of Paycall/Quotecall was roughly 63-65K gas. These were tested using Quark wallets compiled with `--via-ir`. The gas estimation tests also assumed that `scriptSources` are not set and that no scripts are deployed by `CodeJar` during the `QuarkOperation`. The actual cost could be higher if `scriptSources` were set and a script was deployed.