### PR TITLE
CS 5.3 - Small interface updates

### DIFF
--- a/src/quark-core/src/interfaces/IQuarkWallet.sol
+++ b/src/quark-core/src/interfaces/IQuarkWallet.sol
@@ -40,7 +40,6 @@ interface IQuarkWallet {
     function getDigestForQuarkOperation(QuarkOperation calldata op) external view returns (bytes32);
     function getDigestForMultiQuarkOperation(bytes32[] memory opDigests) external pure returns (bytes32);
     function getDigestForQuarkMessage(bytes memory message) external view returns (bytes32);
-    function isValidSignature(bytes32 hash, bytes memory signature) external view returns (bytes4);
     function executeScriptWithNonceLock(address scriptAddress, bytes memory scriptCalldata)
         external
         returns (bytes memory);

--- a/src/quark-proxy/src/QuarkMinimalProxy.sol
+++ b/src/quark-proxy/src/QuarkMinimalProxy.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity 0.8.23;
 
-contract QuarkMinimalProxy {
+import {IHasSignerExecutor} from "quark-core/src/interfaces/IHasSignerExecutor.sol";
+
+contract QuarkMinimalProxy is IHasSignerExecutor {
     /// @notice Address of the EOA signer or the EIP-1271 contract that verifies signed operations for this wallet
     address public immutable signer;
 


### PR DESCRIPTION
Two changes:

- Remove `isValidSignature` from `IQuarkWallet` since it is a function that belongs to `IERC1271`
- Have `QuarkMinimalProxy` extend `IHasSignerExecutor`