### PR TITLE
Move off of Compound node provider proxy

### DIFF
--- a/.github/workflows/gas-snapshot.yml
+++ b/.github/workflows/gas-snapshot.yml
@@ -33,7 +33,7 @@ jobs:
             | grep -E '^test'   \
             | tee .gas-snapshot.new
         env:
-          NODE_PROVIDER_BYPASS_KEY: ${{ secrets.NODE_PROVIDER_BYPASS_KEY }}
+          MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
 
       - name: Check diff tolerance
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,4 +38,4 @@ jobs:
           forge test --via-ir
         id: test
         env:
-          NODE_PROVIDER_BYPASS_KEY: ${{ secrets.NODE_PROVIDER_BYPASS_KEY }}
+          MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}

--- a/README.md
+++ b/README.md
@@ -153,23 +153,18 @@ In the root-level `remappings.txt` file, these remappings look ordinary, like `q
 
 Whenever a new remapping is added to `remappings.txt`, a corresponding entry must be added to `remappings-relative.txt` that prefixes the remapping path with `..` to maintain sub-project compiles; this is covered with an example in the [Dependencies](#dependencies) section.
 
-## Fork tests and NODE_PROVIDER_BYPASS_KEY
+## Fork tests and MAINNET_RPC_URL
 
 Some tests require forking mainnet, e.g. to exercise use-cases like
 supplying and borrowing in a comet market.
 
-For a "fork url" we use our rate-limited node provider endpoint at
-`https://node-provider.compound.finance/ethereum-mainnet`. Setting up a
-fork quickly exceeds the rate limits, so we use a bypass key to allow fork
-tests to exceed the rate limits.
+The "fork url" is specified using the environment variable `MAINNET_RPC_URL`.
+It can be any node provider for Ethereum mainnet, such as Infura or Alchemy.
 
-A bypass key for Quark development can be found in 1Password as a
-credential named "Quark Dev node-provider Bypass Key". The key can then be
-set during tests via the environment variable `NODE_PROVIDER_BYPASS_KEY`,
-like so:
+The environment variable can be set when running tests, like so:
 
 ```
-$ NODE_PROVIDER_BYPASS_KEY=... forge test
+$ MAINNET_RPC_URL=... forge test
 ```
 
 ## Updating gas snapshots
@@ -182,7 +177,7 @@ You can accept the diff and update the baseline if the increased gas usage
 is intentional. Just run the following command:
 
 ```sh
-$ NODE_PROVIDER_BYPASS_KEY=... ./script/update-snapshot.sh
+$ MAINNET_RPC_URL=... ./script/update-snapshot.sh
 ```
 
 Then commit the updated snapshot file:

--- a/test/ReplayableTransactions.t.sol
+++ b/test/ReplayableTransactions.t.sol
@@ -45,9 +45,7 @@ contract ReplayableTransactionsTest is Test {
     constructor() {
         // Fork setup
         vm.createSelectFork(
-            string.concat(
-                "https://node-provider.compound.finance/ethereum-mainnet/", vm.envString("NODE_PROVIDER_BYPASS_KEY")
-            ),
+            vm.envString("MAINNET_RPC_URL"),
             18429607 // 2023-10-25 13:24:00 PST
         );
 

--- a/test/quark-core-scripts/ConditionalMulticall.t.sol
+++ b/test/quark-core-scripts/ConditionalMulticall.t.sol
@@ -43,9 +43,7 @@ contract ConditionalMulticallTest is Test {
 
     function setUp() public {
         vm.createSelectFork(
-            string.concat(
-                "https://node-provider.compound.finance/ethereum-mainnet/", vm.envString("NODE_PROVIDER_BYPASS_KEY")
-            ),
+            vm.envString("MAINNET_RPC_URL"),
             18429607 // 2023-10-25 13:24:00 PST
         );
         factory = new QuarkWalletProxyFactory(address(new QuarkWallet(new CodeJar(), new QuarkStateManager())));

--- a/test/quark-core-scripts/Ethcall.t.sol
+++ b/test/quark-core-scripts/Ethcall.t.sol
@@ -41,9 +41,7 @@ contract EthcallTest is Test {
     function setUp() public {
         // Fork setup
         vm.createSelectFork(
-            string.concat(
-                "https://node-provider.compound.finance/ethereum-mainnet/", vm.envString("NODE_PROVIDER_BYPASS_KEY")
-            ),
+            vm.envString("MAINNET_RPC_URL"),
             18429607 // 2023-10-25 13:24:00 PST
         );
 

--- a/test/quark-core-scripts/Multicall.t.sol
+++ b/test/quark-core-scripts/Multicall.t.sol
@@ -53,9 +53,7 @@ contract MulticallTest is Test {
 
     function setUp() public {
         vm.createSelectFork(
-            string.concat(
-                "https://node-provider.compound.finance/ethereum-mainnet/", vm.envString("NODE_PROVIDER_BYPASS_KEY")
-            ),
+            vm.envString("MAINNET_RPC_URL"),
             18429607 // 2023-10-25 13:24:00 PST
         );
         factory = new QuarkWalletProxyFactory(address(new QuarkWallet(new CodeJar(), new QuarkStateManager())));

--- a/test/quark-core-scripts/Paycall.t.sol
+++ b/test/quark-core-scripts/Paycall.t.sol
@@ -76,9 +76,7 @@ contract PaycallTest is Test {
 
     function setUp() public {
         vm.createSelectFork(
-            string.concat(
-                "https://node-provider.compound.finance/ethereum-mainnet/", vm.envString("NODE_PROVIDER_BYPASS_KEY")
-            ),
+            vm.envString("MAINNET_RPC_URL"),
             18429607 // 2023-10-25 13:24:00 PST
         );
         factory = new QuarkWalletProxyFactory(address(new QuarkWallet(new CodeJar(), new QuarkStateManager())));

--- a/test/quark-core-scripts/Quotecall.t.sol
+++ b/test/quark-core-scripts/Quotecall.t.sol
@@ -77,9 +77,7 @@ contract QuotecallTest is Test {
 
     function setUp() public {
         vm.createSelectFork(
-            string.concat(
-                "https://node-provider.compound.finance/ethereum-mainnet/", vm.envString("NODE_PROVIDER_BYPASS_KEY")
-            ),
+            vm.envString("MAINNET_RPC_URL"),
             18429607 // 2023-10-25 13:24:00 PST
         );
         factory = new QuarkWalletProxyFactory(address(new QuarkWallet(new CodeJar(), new QuarkStateManager())));

--- a/test/quark-core-scripts/UniswapFlashLoan.t.sol
+++ b/test/quark-core-scripts/UniswapFlashLoan.t.sol
@@ -51,9 +51,7 @@ contract UniswapFlashLoanTest is Test {
 
     function setUp() public {
         vm.createSelectFork(
-            string.concat(
-                "https://node-provider.compound.finance/ethereum-mainnet/", vm.envString("NODE_PROVIDER_BYPASS_KEY")
-            ),
+            vm.envString("MAINNET_RPC_URL"),
             18429607 // 2023-10-25 13:24:00 PST
         );
         factory = new QuarkWalletProxyFactory(address(new QuarkWallet(new CodeJar(), new QuarkStateManager())));

--- a/test/quark-core-scripts/UniswapFlashSwapExactOut.t.sol
+++ b/test/quark-core-scripts/UniswapFlashSwapExactOut.t.sol
@@ -47,9 +47,7 @@ contract UniswapFlashSwapExactOutTest is Test {
 
     function setUp() public {
         vm.createSelectFork(
-            string.concat(
-                "https://node-provider.compound.finance/ethereum-mainnet/", vm.envString("NODE_PROVIDER_BYPASS_KEY")
-            ),
+            vm.envString("MAINNET_RPC_URL"),
             18429607 // 2023-10-25 13:24:00 PST
         );
         factory = new QuarkWalletProxyFactory(address(new QuarkWallet(new CodeJar(), new QuarkStateManager())));

--- a/test/quark-core/isValidSignature.t.sol
+++ b/test/quark-core/isValidSignature.t.sol
@@ -42,9 +42,7 @@ contract isValidSignatureTest is Test {
     function setUp() public {
         // Fork setup
         vm.createSelectFork(
-            string.concat(
-                "https://node-provider.compound.finance/ethereum-mainnet/", vm.envString("NODE_PROVIDER_BYPASS_KEY")
-            ),
+            vm.envString("MAINNET_RPC_URL"),
             18429607 // 2023-10-25 13:24:00 PST
         );
 


### PR DESCRIPTION
Instead of hardcoding the fork url to be the Compound node provider proxy, we introduce a new `MAINNET_RPC_URL` env variable to allow the developer to set their own node provider.