### PR TITLE
Nonce as Non-Replayable Submission Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For example, let _Wallet A_ be the `executor` of _Wallet B_. Alice is the `signe
 
 ### Replayable Scripts
 
-Replayable scripts are Quark scripts that can re-executed N times using the same signature of a _Quark operation_. More specifically, replayable scripts generate a nonce chain where the original signer knows a secret and hashes that secret N times. The signer can reveal a single "submission token" to replay the script which is easily verified on-chain. When the signer reveals the last submission token (the original secret) and submits it on-chain, no more replays are allowed (assuming the secret was chosen as a strong random). The signer can always cancel replays by submitting a nop non-replayable script on-chain or simply forgetting the secret. Note: the chain can be arbitrarily long and does not expend any additional gas on-chain for being longer (except if a script wants to know its position in the chain).
+Replayable scripts are Quark scripts that can be re-executed N times using the same signature of a _Quark operation_. More specifically, replayable scripts generate a nonce chain where the original signer knows a secret and hashes that secret N times. The signer can reveal a single "submission token" to replay the script which is easily verified on-chain. When the signer reveals the last submission token (the original secret) and submits it on-chain, no more replays are allowed (assuming the secret was chosen as a strong random). The signer can always cancel replays by submitting a nop non-replayable script on-chain or simply forgetting the secret. Note: the chain can be arbitrarily long and does not expend any additional gas on-chain for being longer (except if a script wants to know its position in the chain).
 
 ```
 Nonce hash chain:

--- a/src/quark-core/src/QuarkScript.sol
+++ b/src/quark-core/src/QuarkScript.sol
@@ -132,7 +132,7 @@ abstract contract QuarkScript {
     }
 
     // Note: this may not be accurate after any nested calls from a script
-    function getActiveNonce() internal returns (bytes32) {
+    function getActiveNonce() internal view returns (bytes32) {
         bytes32 activeNonceSlot = ACTIVE_NONCE_SLOT;
         bytes32 value;
         assembly {
@@ -143,7 +143,7 @@ abstract contract QuarkScript {
     }
 
     // Note: this may not be accurate after any nested calls from a script
-    function getActiveSubmissionToken() internal returns (bytes32) {
+    function getActiveSubmissionToken() internal view returns (bytes32) {
         bytes32 activeSubmissionTokenSlot = ACTIVE_SUBMISSION_TOKEN_SLOT;
         bytes32 value;
         assembly {
@@ -155,7 +155,7 @@ abstract contract QuarkScript {
     // Note: this may not be accurate after any nested calls from a script
     // Returns the active replay count of this script. Thus, the first submission should return 0,
     // the second submission 1, and so on. This must be called before the script makes any external calls.
-    function getActiveReplayCount() internal returns (uint256) {
+    function getActiveReplayCount() internal view returns (uint256) {
         bytes32 nonce = getActiveNonce();
         bytes32 submissionToken = getActiveSubmissionToken();
         uint256 n;

--- a/test/ReplayableTransactions.t.sol
+++ b/test/ReplayableTransactions.t.sol
@@ -185,7 +185,7 @@ contract ReplayableTransactionsTest is Test {
         QuarkWallet.QuarkOperation memory cancelOp = new QuarkOperationHelper().newBasicOpWithCalldata(
             aliceWallet,
             recurringPurchase,
-            abi.encodeWithSelector(RecurringPurchase.cancel.selector),
+            abi.encodeWithSelector(RecurringPurchase.nop.selector),
             ScriptType.ScriptAddress
         );
         cancelOp.nonce = op.nonce;
@@ -262,7 +262,7 @@ contract ReplayableTransactionsTest is Test {
             cancelOp = new QuarkOperationHelper().newBasicOpWithCalldata(
                 aliceWallet,
                 recurringPurchase,
-                abi.encodeWithSelector(RecurringPurchase.cancel.selector),
+                abi.encodeWithSelector(RecurringPurchase.nop.selector),
                 ScriptType.ScriptAddress
             );
             cancelOp.expiry = op2.expiry;

--- a/test/lib/Incrementer.sol
+++ b/test/lib/Incrementer.sol
@@ -25,3 +25,14 @@ contract Incrementer {
         incrementCounter(Counter(counter));
     }
 }
+
+contract IncrementerBySix {
+    function incrementCounter(Counter counter) public {
+        Counter(counter).increment();
+        Counter(counter).increment();
+        Counter(counter).increment();
+        Counter(counter).increment();
+        Counter(counter).increment();
+        Counter(counter).increment();
+    }
+}

--- a/test/lib/Noncer.sol
+++ b/test/lib/Noncer.sol
@@ -9,6 +9,7 @@ contract Stow {
 
     function getNestedOperation()
         public
+        view
         returns (QuarkWallet.QuarkOperation memory op, bytes32 submissionToken, uint8 v, bytes32 r, bytes32 s)
     {
         (op, submissionToken, v, r, s) =
@@ -27,15 +28,15 @@ contract Stow {
 }
 
 contract Noncer is QuarkScript {
-    function checkNonce() public returns (bytes32) {
+    function checkNonce() public view returns (bytes32) {
         return getActiveNonce();
     }
 
-    function checkSubmissionToken() public returns (bytes32) {
+    function checkSubmissionToken() public view returns (bytes32) {
         return getActiveSubmissionToken();
     }
 
-    function checkReplayCount() public returns (uint256) {
+    function checkReplayCount() public view returns (uint256) {
         return getActiveReplayCount();
     }
 

--- a/test/lib/RecurringPurchase.sol
+++ b/test/lib/RecurringPurchase.sol
@@ -94,8 +94,8 @@ contract RecurringPurchase is QuarkScript {
         );
     }
 
-    function cancel() external {
-        // Not explicitly clearing the nonce just cancels the replayable txn
+    function nop() external {
+        // used to no-op and cancel script
     }
 
     function hashConfig(PurchaseConfig calldata config) internal pure returns (bytes32) {

--- a/test/quark-core/EIP712.t.sol
+++ b/test/quark-core/EIP712.t.sol
@@ -232,11 +232,7 @@ contract EIP712Test is Test {
         // submitter tries to reuse the same signature twice, for a non-replayable operation
         vm.expectRevert(
             abi.encodeWithSelector(
-                QuarkNonceManager.NonReplayableNonce.selector,
-                address(wallet),
-                op.nonce,
-                bytes32(type(uint256).max),
-                true
+                QuarkNonceManager.NonReplayableNonce.selector, address(wallet), op.nonce, op.nonce, true
             )
         );
         wallet.executeQuarkOperation(op, v, r, s);

--- a/test/quark-core/Noncer.t.sol
+++ b/test/quark-core/Noncer.t.sol
@@ -92,7 +92,8 @@ contract NoncerTest is Test {
         bytes memory result = aliceWallet.executeQuarkOperation(op, v, r, s);
 
         (bytes32 submissionTokenResult) = abi.decode(result, (bytes32));
-        assertEq(submissionTokenResult, EXHAUSTED_TOKEN);
+        assertEq(submissionTokenResult, op.nonce);
+        assertEq(nonceManager.submissions(address(aliceWallet), op.nonce), bytes32(type(uint256).max));
     }
 
     function testGetActiveReplayCountSingle() public {
@@ -182,14 +183,14 @@ contract NoncerTest is Test {
         bytes memory result = aliceWallet.executeQuarkOperation(op, v, r, s);
 
         (bytes32 pre, bytes32 post, bytes memory innerResult) = abi.decode(result, (bytes32, bytes32, bytes));
-        assertEq(pre, EXHAUSTED_TOKEN);
+        assertEq(pre, op.nonce);
         assertEq(post, bytes32(0));
         bytes32 innerNonce = abi.decode(innerResult, (bytes32));
-        assertEq(innerNonce, EXHAUSTED_TOKEN);
+        assertEq(innerNonce, nestedOp.nonce);
     }
 
     // Complicated test for a nested script to call itself recursive, since it's fun to test wonky cases.
-    function testGetActiveSubmissionTokenSharedReplayNested() public {
+    function testNestedPlayPullingActiveReplayCount() public {
         Stow stow = new Stow();
 
         // gas: do not meter set-up


### PR DESCRIPTION
Previously in `QuarkNonceManager`, we used `submissionToken=EXHAUSTED` for non-replayable submissions and `submissionToken=nonce` for the first play of replayable submissions. Overall, this behavior was inconsistent (though otherwise fine) and generally unobservable. With the addition of `getActiveSubmissionToken`, this behavior became obervable and showed its inconsistencies. This patch changes the defined behavior making it where we submit `submissionToken=nonce` for the first play or a single-use or replayable quark operation, but still retain the behavior that `submissions[nonce]=EXHAUSTED` for non-replayables. This ends up as a reduction in the overall code complexity.

The only true behavior this changes is that we must (and should) ban `nonce=bytes32(0)` (and for the sake of consistency also `nonce=bytes32(uint_max)`). This is because we would be submitting with `submissionToken=FREE` for that nonce and overall it isn't worth the risk of allowing that (since it wouldn't, but _could_ lead to unlimited replays if other code isn't implemented correctly).

Overall, I think this change is a net benefit in reduction of code complexity and better understandability from the end-user's perspective.