### PR TITLE
Library Values

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
-solc = "0.8.23"
-evm_version = "paris"
+solc = "0.8.27"
+evm_version = "cancun"
 
 libs = [ "./lib" ]
 

--- a/script/DeployCodeJarFactory.s.sol
+++ b/script/DeployCodeJarFactory.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Script.sol";
 import "forge-std/console.sol";

--- a/script/DeployQuarkWalletFactory.s.sol
+++ b/script/DeployQuarkWalletFactory.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Script.sol";
 import "forge-std/console.sol";

--- a/src/codejar/foundry.toml
+++ b/src/codejar/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
-solc = "0.8.23"
-evm_version = "paris"
+solc = "0.8.27"
+evm_version = "cancun"
 
 libs = [ "../../lib" ]
 

--- a/src/codejar/src/CodeJar.sol
+++ b/src/codejar/src/CodeJar.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 /**
  * @title Code Jar

--- a/src/codejar/src/CodeJarFactory.sol
+++ b/src/codejar/src/CodeJarFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {CodeJar} from "codejar/src/CodeJar.sol";
 

--- a/src/quark-core-scripts/foundry.toml
+++ b/src/quark-core-scripts/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
-solc = "0.8.23"
-evm_version = "paris"
+solc = "0.8.27"
+evm_version = "cancun"
 
 libs = [ "../../lib" ]
 

--- a/src/quark-core-scripts/src/Cancel.sol
+++ b/src/quark-core-scripts/src/Cancel.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.27;
+
+import {IQuarkWallet} from "quark-core/src/QuarkWallet.sol";
+import {QuarkNonceManager} from "quark-core/src/QuarkNonceManager.sol";
+
+/**
+ * @title Cancel Core Script
+ * @notice Core transaction script that can be used to cancel quark operations.
+ * @author Legend Labs, Inc.
+ */
+contract Cancel {
+    /**
+     * @notice May cancel a script by being run as a no-op (no operation).
+     */
+    function nop() external pure {}
+
+    /**
+     * @notice Cancels a script by calling into nonce manager to cancel the script's nonce.
+     * @param nonce The nonce of the quark operation to cancel (exhaust)
+     */
+    function cancel(bytes32 nonce) external {
+        nonceManager().cancel(nonce);
+    }
+
+    /**
+     * @notice Cancels many scripts by calling into nonce manager to cancel each script's nonce.
+     * @param nonces A list of nonces of the quark operations to cancel (exhaust)
+     */
+    function cancelMany(bytes32[] calldata nonces) external {
+        QuarkNonceManager manager = nonceManager();
+        for (uint256 i = 0; i < nonces.length; ++i) {
+            bytes32 nonce = nonces[i];
+            manager.cancel(nonce);
+        }
+    }
+
+    function nonceManager() internal view returns (QuarkNonceManager) {
+        return QuarkNonceManager(IQuarkWallet(address(this)).nonceManager());
+    }
+}

--- a/src/quark-core-scripts/src/ConditionalMulticall.sol
+++ b/src/quark-core-scripts/src/ConditionalMulticall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "quark-core-scripts/src/lib/ConditionalChecker.sol";
 

--- a/src/quark-core-scripts/src/Ethcall.sol
+++ b/src/quark-core-scripts/src/Ethcall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 /**
  * @title Ethcall Core Script

--- a/src/quark-core-scripts/src/Multicall.sol
+++ b/src/quark-core-scripts/src/Multicall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 /**
  * @title Multicall Core Script

--- a/src/quark-core-scripts/src/Paycall.sol
+++ b/src/quark-core-scripts/src/Paycall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "quark-core-scripts/src/vendor/chainlink/AggregatorV3Interface.sol";
 import "openzeppelin/token/ERC20/utils/SafeERC20.sol";

--- a/src/quark-core-scripts/src/Quotecall.sol
+++ b/src/quark-core-scripts/src/Quotecall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "quark-core-scripts/src/vendor/chainlink/AggregatorV3Interface.sol";
 import "openzeppelin/token/ERC20/utils/SafeERC20.sol";

--- a/src/quark-core-scripts/src/UniswapFlashLoan.sol
+++ b/src/quark-core-scripts/src/UniswapFlashLoan.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "openzeppelin/token/ERC20/utils/SafeERC20.sol";
 import "v3-core/contracts/interfaces/IUniswapV3Pool.sol";

--- a/src/quark-core-scripts/src/UniswapFlashSwapExactOut.sol
+++ b/src/quark-core-scripts/src/UniswapFlashSwapExactOut.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "openzeppelin/token/ERC20/utils/SafeERC20.sol";
 import "v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.sol";

--- a/src/quark-core-scripts/src/lib/ConditionalChecker.sol
+++ b/src/quark-core-scripts/src/lib/ConditionalChecker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 library ConditionalChecker {
     enum CheckType {

--- a/src/quark-core-scripts/src/lib/UniswapFactoryAddress.sol
+++ b/src/quark-core-scripts/src/lib/UniswapFactoryAddress.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 library UniswapFactoryAddress {
     // Reference: https://docs.uniswap.org/contracts/v3/reference/deployments

--- a/src/quark-core-scripts/src/vendor/manifest.json
+++ b/src/quark-core-scripts/src/vendor/manifest.json
@@ -16,7 +16,7 @@
                     "newLines": 6,
                     "lines": [
                         " // SPDX-License-Identifier: GPL-2.0-or-later",
-                        "-pragma solidity 0.8.23;",
+                        "-pragma solidity 0.8.27;",
                         "+pragma solidity >=0.5.0;",
                         " ",
                         " /// @title Provides functions for deriving a pool address from the factory, tokens, and the fee",

--- a/src/quark-core-scripts/src/vendor/uniswap_v3_periphery/PoolAddress.sol
+++ b/src/quark-core-scripts/src/vendor/uniswap_v3_periphery/PoolAddress.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 /// @title Provides functions for deriving a pool address from the factory, tokens, and the fee
 library PoolAddress {

--- a/src/quark-core/foundry.toml
+++ b/src/quark-core/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
-solc = "0.8.23"
-evm_version = "paris"
+solc = "0.8.27"
+evm_version = "cancun"
 
 libs = [ "../../lib" ]
 

--- a/src/quark-core/src/QuarkNonceManager.sol
+++ b/src/quark-core/src/QuarkNonceManager.sol
@@ -3,6 +3,14 @@ pragma solidity 0.8.23;
 
 import {IQuarkWallet} from "quark-core/src/interfaces/IQuarkWallet.sol";
 
+library QuarkNonceManagerMetadata {
+    /// @notice Represents the unclaimed bytes32 value.
+    bytes32 internal constant FREE = bytes32(uint256(0));
+
+    /// @notice A token that implies a Quark Operation is no longer replayable.
+    bytes32 internal constant EXHAUSTED = bytes32(type(uint256).max);
+}
+
 /**
  * @title Quark Nonce Manager
  * @notice Contract for managing nonces for Quark wallets
@@ -16,10 +24,10 @@ contract QuarkNonceManager {
     event NonceSubmitted(address wallet, bytes32 nonce, bytes32 submissionToken);
 
     /// @notice Represents the unclaimed bytes32 value.
-    bytes32 public constant FREE = bytes32(uint256(0));
+    bytes32 public constant FREE = QuarkNonceManagerMetadata.FREE;
 
     /// @notice A token that implies a Quark Operation is no longer replayable.
-    bytes32 public constant EXHAUSTED = bytes32(type(uint256).max);
+    bytes32 public constant EXHAUSTED = QuarkNonceManagerMetadata.EXHAUSTED;
 
     /// @notice Mapping from nonces to last used submission token.
     mapping(address wallet => mapping(bytes32 nonce => bytes32 lastToken)) public submissions;

--- a/src/quark-core/src/QuarkNonceManager.sol
+++ b/src/quark-core/src/QuarkNonceManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {IQuarkWallet} from "quark-core/src/interfaces/IQuarkWallet.sol";
 
@@ -22,6 +22,7 @@ contract QuarkNonceManager {
     error InvalidSubmissionToken(address wallet, bytes32 nonce, bytes32 submissionToken);
 
     event NonceSubmitted(address wallet, bytes32 nonce, bytes32 submissionToken);
+    event NonceCanceled(address wallet, bytes32 nonce);
 
     /// @notice Represents the unclaimed bytes32 value.
     bytes32 public constant FREE = QuarkNonceManagerMetadata.FREE;
@@ -31,6 +32,15 @@ contract QuarkNonceManager {
 
     /// @notice Mapping from nonces to last used submission token.
     mapping(address wallet => mapping(bytes32 nonce => bytes32 lastToken)) public submissions;
+
+    /**
+     * @notice Ensures a given nonce is canceled for sender. An un-used nonce will not be usable in the future, and a replayable nonce will no longer be replayable. This is a no-op for already canceled operations.
+     * @param nonce The nonce of the chain to cancel.
+     */
+    function cancel(bytes32 nonce) external {
+        submissions[msg.sender][nonce] = EXHAUSTED;
+        emit NonceCanceled(msg.sender, nonce);
+    }
 
     /**
      * @notice Attempts a first or subsequent submission of a given nonce from a wallet.

--- a/src/quark-core/src/QuarkScript.sol
+++ b/src/quark-core/src/QuarkScript.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
-import {QuarkWallet, QuarkWalletMetadata, IHasSignerExecutor} from "quark-core/src/QuarkWallet.sol";
-import {QuarkNonceManagerMetadata} from "quark-core/src/QuarkNonceManager.sol";
+import {QuarkWallet, QuarkWalletMetadata, IHasSignerExecutor, IQuarkWallet} from "quark-core/src/QuarkWallet.sol";
+import {QuarkNonceManager, QuarkNonceManagerMetadata} from "quark-core/src/QuarkNonceManager.sol";
 
 /**
  * @title Quark Script
@@ -13,6 +13,7 @@ abstract contract QuarkScript {
     error ReentrantCall();
     error InvalidActiveNonce();
     error InvalidActiveSubmissionToken();
+    error NoActiveNonce();
 
     /// @notice Storage location for the re-entrancy guard
     bytes32 internal constant REENTRANCY_FLAG_SLOT =
@@ -22,21 +23,20 @@ abstract contract QuarkScript {
     modifier nonReentrant() {
         bytes32 slot = REENTRANCY_FLAG_SLOT;
         bytes32 flag;
-        // TODO: Move to TSTORE after updating Solidity version to >=0.8.24
         assembly {
-            flag := sload(slot)
+            flag := tload(slot)
         }
         if (flag == bytes32(uint256(1))) {
             revert ReentrantCall();
         }
         assembly {
-            sstore(slot, 1)
+            tstore(slot, 1)
         }
 
         _;
 
         assembly {
-            sstore(slot, 0)
+            tstore(slot, 0)
         }
     }
 
@@ -69,21 +69,23 @@ abstract contract QuarkScript {
         return IHasSignerExecutor(address(this)).executor();
     }
 
+    function nonceManager() internal view returns (QuarkNonceManager) {
+        return QuarkNonceManager(IQuarkWallet(address(this)).nonceManager());
+    }
+
     function allowCallback() internal {
         bytes32 callbackSlot = QuarkWalletMetadata.CALLBACK_SLOT;
         bytes32 activeScriptSlot = QuarkWalletMetadata.ACTIVE_SCRIPT_SLOT;
         assembly {
-            // TODO: Move to TLOAD/TSTORE after updating Solidity version to >=0.8.24
-            let activeScript := sload(activeScriptSlot)
-            sstore(callbackSlot, activeScript)
+            let activeScript := tload(activeScriptSlot)
+            tstore(callbackSlot, activeScript)
         }
     }
 
     function clearCallback() internal {
         bytes32 callbackSlot = QuarkWalletMetadata.CALLBACK_SLOT;
         assembly {
-            // TODO: Move to TSTORE after updating Solidity version to >=0.8.24
-            sstore(callbackSlot, 0)
+            tstore(callbackSlot, 0)
         }
     }
 
@@ -97,8 +99,9 @@ abstract contract QuarkScript {
 
     function read(bytes32 key) internal view returns (bytes32) {
         bytes32 value;
+        bytes32 isolatedKey = getNonceIsolatedKey(key);
         assembly {
-            value := sload(key)
+            value := sload(isolatedKey)
         }
         return value;
     }
@@ -111,12 +114,21 @@ abstract contract QuarkScript {
         return write(keccak256(bytes(key)), value);
     }
 
-    // TODO: Consider adding nonce-based scoping by TLOAD'ing the nonce and using
-    // that to hash the key.
     function write(bytes32 key, bytes32 value) internal {
+        bytes32 isolatedKey = getNonceIsolatedKey(key);
         assembly {
-            sstore(key, value)
+            sstore(isolatedKey, value)
         }
+    }
+
+    // Returns a key isolated to the active nonce of a script
+    // This provide cooperative isolation of storage between scripts.
+    function getNonceIsolatedKey(bytes32 key) internal view returns (bytes32) {
+        bytes32 nonce = getActiveNonce();
+        if (nonce == bytes32(0)) {
+            revert NoActiveNonce();
+        }
+        return keccak256(abi.encodePacked(nonce, key));
     }
 
     // Note: this may not be accurate after any nested calls from a script
@@ -124,7 +136,7 @@ abstract contract QuarkScript {
         bytes32 activeNonceSlot = QuarkWalletMetadata.ACTIVE_NONCE_SLOT;
         bytes32 value;
         assembly {
-            value := sload(activeNonceSlot)
+            value := tload(activeNonceSlot)
         }
 
         return value;
@@ -135,7 +147,7 @@ abstract contract QuarkScript {
         bytes32 activeSubmissionTokenSlot = QuarkWalletMetadata.ACTIVE_SUBMISSION_TOKEN_SLOT;
         bytes32 value;
         assembly {
-            value := sload(activeSubmissionTokenSlot)
+            value := tload(activeSubmissionTokenSlot)
         }
         return value;
     }

--- a/src/quark-core/src/QuarkWallet.sol
+++ b/src/quark-core/src/QuarkWallet.sol
@@ -39,6 +39,19 @@ library QuarkWalletMetadata {
     /// @notice The EIP-712 domain typehash used for MultiQuarkOperations for this version of QuarkWallet
     bytes32 internal constant MULTI_QUARK_OPERATION_DOMAIN_TYPEHASH =
         keccak256("EIP712Domain(string name,string version)");
+
+    /// @notice Well-known storage slot for the currently executing script's callback address (if any)
+    bytes32 internal constant CALLBACK_SLOT = bytes32(uint256(keccak256("quark.v1.callback")) - 1);
+
+    /// @notice Well-known storage slot for the currently executing script's address (if any)
+    bytes32 internal constant ACTIVE_SCRIPT_SLOT = bytes32(uint256(keccak256("quark.v1.active.script")) - 1);
+
+    /// @notice Well-known storage slot for the nonce of the script that's currently executing.
+    bytes32 internal constant ACTIVE_NONCE_SLOT = bytes32(uint256(keccak256("quark.v1.active.nonce")) - 1);
+
+    /// @notice Well-known storage slot for the submission token of the script thatg's currently executing.
+    bytes32 internal constant ACTIVE_SUBMISSION_TOKEN_SLOT =
+        bytes32(uint256(keccak256("quark.v1.active.submissionToken")) - 1);
 }
 
 /**
@@ -112,17 +125,16 @@ contract QuarkWallet is IERC1271 {
     );
 
     /// @notice Well-known storage slot for the currently executing script's callback address (if any)
-    bytes32 public constant CALLBACK_SLOT = bytes32(uint256(keccak256("quark.v1.callback")) - 1);
+    bytes32 public constant CALLBACK_SLOT = QuarkWalletMetadata.CALLBACK_SLOT;
 
     /// @notice Well-known storage slot for the currently executing script's address (if any)
-    bytes32 public constant ACTIVE_SCRIPT_SLOT = bytes32(uint256(keccak256("quark.v1.active.script")) - 1);
+    bytes32 public constant ACTIVE_SCRIPT_SLOT = QuarkWalletMetadata.ACTIVE_SCRIPT_SLOT;
 
-    /// @notice Well-known --
-    bytes32 public constant ACTIVE_NONCE_SLOT = bytes32(uint256(keccak256("quark.v1.active.nonce")) - 1);
+    /// @notice Well-known storage slot for the nonce of the script that's currently executing.
+    bytes32 public constant ACTIVE_NONCE_SLOT = QuarkWalletMetadata.ACTIVE_NONCE_SLOT;
 
-    /// @notice Well-known --
-    bytes32 public constant ACTIVE_SUBMISSION_TOKEN_SLOT =
-        bytes32(uint256(keccak256("quark.v1.active.submissionToken")) - 1);
+    /// @notice Well-known storage slot for the submission token of the script thatg's currently executing.
+    bytes32 public constant ACTIVE_SUBMISSION_TOKEN_SLOT = QuarkWalletMetadata.ACTIVE_SUBMISSION_TOKEN_SLOT;
 
     /// @notice The magic value to return for valid ERC1271 signature
     bytes4 internal constant EIP_1271_MAGIC_VALUE = 0x1626ba7e;

--- a/src/quark-core/src/QuarkWallet.sol
+++ b/src/quark-core/src/QuarkWallet.sol
@@ -8,6 +8,7 @@ import {CodeJar} from "codejar/src/CodeJar.sol";
 
 import {QuarkNonceManager} from "quark-core/src/QuarkNonceManager.sol";
 import {IHasSignerExecutor} from "quark-core/src/interfaces/IHasSignerExecutor.sol";
+import {IQuarkWallet} from "quark-core/src/interfaces/IQuarkWallet.sol";
 
 /**
  * @title Quark Wallet Metadata

--- a/src/quark-core/src/QuarkWallet.sol
+++ b/src/quark-core/src/QuarkWallet.sol
@@ -49,7 +49,7 @@ library QuarkWalletMetadata {
     /// @notice Well-known storage slot for the nonce of the script that's currently executing.
     bytes32 internal constant ACTIVE_NONCE_SLOT = bytes32(uint256(keccak256("quark.v1.active.nonce")) - 1);
 
-    /// @notice Well-known storage slot for the submission token of the script thatg's currently executing.
+    /// @notice Well-known storage slot for the submission token of the script that's currently executing.
     bytes32 internal constant ACTIVE_SUBMISSION_TOKEN_SLOT =
         bytes32(uint256(keccak256("quark.v1.active.submissionToken")) - 1);
 }
@@ -134,7 +134,7 @@ contract QuarkWallet is IERC1271 {
     /// @notice Well-known storage slot for the nonce of the script that's currently executing.
     bytes32 public constant ACTIVE_NONCE_SLOT = QuarkWalletMetadata.ACTIVE_NONCE_SLOT;
 
-    /// @notice Well-known storage slot for the submission token of the script thatg's currently executing.
+    /// @notice Well-known storage slot for the submission token of the script that's currently executing.
     bytes32 public constant ACTIVE_SUBMISSION_TOKEN_SLOT = QuarkWalletMetadata.ACTIVE_SUBMISSION_TOKEN_SLOT;
 
     /// @notice The magic value to return for valid ERC1271 signature

--- a/src/quark-core/src/QuarkWalletStandalone.sol
+++ b/src/quark-core/src/QuarkWalletStandalone.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {CodeJar} from "codejar/src/CodeJar.sol";
 

--- a/src/quark-core/src/interfaces/IHasSignerExecutor.sol
+++ b/src/quark-core/src/interfaces/IHasSignerExecutor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 /**
  * @title Has Signer and Executor interface

--- a/src/quark-core/src/interfaces/IQuarkWallet.sol
+++ b/src/quark-core/src/interfaces/IQuarkWallet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 /**
  * @title Quark Wallet interface
@@ -21,6 +21,7 @@ interface IQuarkWallet {
         uint256 expiry;
     }
 
+    function nonceManager() external view returns (address);
     function executeQuarkOperation(QuarkOperation calldata op, uint8 v, bytes32 r, bytes32 s)
         external
         returns (bytes memory);

--- a/src/quark-core/src/periphery/BatchExecutor.sol
+++ b/src/quark-core/src/periphery/BatchExecutor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {QuarkWallet} from "quark-core/src/QuarkWallet.sol";
 

--- a/src/quark-factory/foundry.toml
+++ b/src/quark-factory/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
-solc = "0.8.23"
-evm_version = "paris"
+solc = "0.8.27"
+evm_version = "cancun"
 
 libs = [ "../../lib" ]
 

--- a/src/quark-factory/src/QuarkFactory.sol
+++ b/src/quark-factory/src/QuarkFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {CodeJar} from "codejar/src/CodeJar.sol";
 import {QuarkWallet} from "quark-core/src/QuarkWallet.sol";

--- a/src/quark-proxy/foundry.toml
+++ b/src/quark-proxy/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
-solc = "0.8.23"
-evm_version = "paris"
+solc = "0.8.27"
+evm_version = "cancun"
 
 libs = [ "../../lib" ]
 

--- a/src/quark-proxy/src/QuarkMinimalProxy.sol
+++ b/src/quark-proxy/src/QuarkMinimalProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {IHasSignerExecutor} from "quark-core/src/interfaces/IHasSignerExecutor.sol";
 

--- a/src/quark-proxy/src/QuarkWalletProxyFactory.sol
+++ b/src/quark-proxy/src/QuarkWalletProxyFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {QuarkWallet, QuarkWalletMetadata} from "quark-core/src/QuarkWallet.sol";
 

--- a/test/ReplayableTransactions.t.sol
+++ b/test/ReplayableTransactions.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/codejar/CodeJar.t.sol
+++ b/test/codejar/CodeJar.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/lib/AllowCallbacks.sol
+++ b/test/lib/AllowCallbacks.sol
@@ -1,24 +1,36 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "quark-core/src/QuarkScript.sol";
 import "quark-core/src/QuarkWallet.sol";
 
+interface IComeback {
+    function request() external returns (uint256);
+}
+
+contract Comebacker {
+    function comeback() public returns (uint256) {
+        return IComeback(msg.sender).request() + 1;
+    }
+}
+
 contract AllowCallbacks is QuarkScript {
-    function run(address callbackAddress) public {
-        QuarkWallet self = QuarkWallet(payable(address(this)));
-        bytes32 CALLBACK_SLOT = self.CALLBACK_SLOT();
-        bytes32 data = bytes32(uint256(uint160(callbackAddress)));
-        assembly {
-            sstore(CALLBACK_SLOT, data)
-        }
-    }
-
-    function allowCallbackFun() public {
+    function run() public returns (uint256) {
         allowCallback();
+        return new Comebacker().comeback() * 2;
     }
 
-    function clearCallbackFun() public {
+    function runAllowThenClear() public returns (uint256) {
+        allowCallback();
         clearCallback();
+        return new Comebacker().comeback() * 2;
+    }
+
+    function runWithoutAllow() public returns (uint256) {
+        return new Comebacker().comeback() * 2;
+    }
+
+    function request() external view returns (uint256) {
+        return 100 + getActiveReplayCount();
     }
 }

--- a/test/lib/CallbackFromCounter.sol
+++ b/test/lib/CallbackFromCounter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "test/lib/Counter.sol";
 import "quark-core/src/QuarkScript.sol";

--- a/test/lib/CallcodeReentrancy.sol
+++ b/test/lib/CallcodeReentrancy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/console.sol";
 

--- a/test/lib/CancelOtherScript.sol
+++ b/test/lib/CancelOtherScript.sol
@@ -11,15 +11,15 @@ contract CancelOtherScript is QuarkScript {
         emit CancelNonce();
     }
 
-    function checkNonce() public returns (bytes32) {
+    function checkNonce() public view returns (bytes32) {
         return getActiveNonce();
     }
 
-    function checkSubmissionToken() public returns (bytes32) {
+    function checkSubmissionToken() public view returns (bytes32) {
         return getActiveSubmissionToken();
     }
 
-    function checkReplayCount() public returns (uint256) {
+    function checkReplayCount() public view returns (uint256) {
         return getActiveReplayCount();
     }
 }

--- a/test/lib/CheckNonceScript.sol
+++ b/test/lib/CheckNonceScript.sol
@@ -1,16 +1,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "quark-core/src/QuarkWallet.sol";
 import "quark-core/src/QuarkScript.sol";
 
-contract CancelOtherScript is QuarkScript {
-    event CancelNonce();
-
-    function run() public {
-        emit CancelNonce();
-    }
-
+contract CheckNonceScript is QuarkScript {
     function checkNonce() public view returns (bytes32) {
         return getActiveNonce();
     }

--- a/test/lib/ConstructorReverter.sol
+++ b/test/lib/ConstructorReverter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 contract ConstructorReverter {
     error Test(uint256);

--- a/test/lib/Counter.sol
+++ b/test/lib/Counter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 interface HasCallback {
     function callback() external payable;

--- a/test/lib/CounterScript.sol
+++ b/test/lib/CounterScript.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "test/lib/Counter.sol";
 

--- a/test/lib/DeFiScripts.sol
+++ b/test/lib/DeFiScripts.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";

--- a/test/lib/EIP1271Signer.sol
+++ b/test/lib/EIP1271Signer.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 contract EIP1271Signer {
     bytes4 internal constant EIP_1271_MAGIC_VALUE = 0x1626ba7e;

--- a/test/lib/EmptyCode.sol
+++ b/test/lib/EmptyCode.sol
@@ -1,4 +1,4 @@
-pragma solidity "0.8.23";
+pragma solidity "0.8.27";
 
 contract EmptyCode {
     // NOTE: force the solidity compiler to produce empty code when this is deployed

--- a/test/lib/EvilReceiver.sol
+++ b/test/lib/EvilReceiver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "quark-core/src/QuarkWallet.sol";
 import "quark-core/src/QuarkScript.sol";

--- a/test/lib/ExecuteOnBehalf.sol
+++ b/test/lib/ExecuteOnBehalf.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "quark-core/src/QuarkWallet.sol";
 

--- a/test/lib/ExecuteOtherOperation.sol
+++ b/test/lib/ExecuteOtherOperation.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "quark-core/src/QuarkWallet.sol";
 import "quark-core/src/QuarkScript.sol";

--- a/test/lib/ExecuteWithRequirements.sol
+++ b/test/lib/ExecuteWithRequirements.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "quark-core/src/QuarkWallet.sol";
 import "quark-core/src/QuarkNonceManager.sol";

--- a/test/lib/GetMessageDetails.sol
+++ b/test/lib/GetMessageDetails.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 contract GetMessageDetails {
     function getMsgSenderAndValue() external payable returns (address, uint256) {

--- a/test/lib/Incrementer.sol
+++ b/test/lib/Incrementer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "test/lib/Counter.sol";
 

--- a/test/lib/Logger.sol
+++ b/test/lib/Logger.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 contract Logger {
     event Ping(uint256);

--- a/test/lib/MaxCounterScript.sol
+++ b/test/lib/MaxCounterScript.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "quark-core/src/QuarkScript.sol";
 import "test/lib/Counter.sol";

--- a/test/lib/Mememe.sol
+++ b/test/lib/Mememe.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 contract Mememe {
     address public immutable me;

--- a/test/lib/Noncer.sol
+++ b/test/lib/Noncer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {QuarkScript} from "quark-core/src/QuarkScript.sol";
 import {QuarkWallet} from "quark-core/src/QuarkWallet.sol";
@@ -72,6 +72,14 @@ contract Noncer is QuarkScript {
         post = getActiveReplayCount();
 
         return (pre, post, result);
+    }
+
+    function postNestRead(QuarkWallet.QuarkOperation memory op, uint8 v, bytes32 r, bytes32 s)
+        public
+        returns (uint256)
+    {
+        QuarkWallet(payable(address(this))).executeQuarkOperation(op, v, r, s);
+        return readU256("count");
     }
 
     function nestedPlay(Stow stow) public returns (uint256) {

--- a/test/lib/Permit2Helper.sol
+++ b/test/lib/Permit2Helper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 interface Permit2 {
     function permit(address owner, Permit2Helper.PermitSingle memory permitSingle, bytes calldata signature) external;

--- a/test/lib/PrecompileCaller.sol
+++ b/test/lib/PrecompileCaller.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 contract PrecompileCaller {
     // 0x01

--- a/test/lib/QuarkOperationHelper.sol
+++ b/test/lib/QuarkOperationHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "quark-core/src/QuarkWallet.sol";
@@ -39,13 +39,36 @@ contract QuarkOperationHelper is Test {
         bytes[] memory ensureScripts,
         ScriptType scriptType
     ) public returns (QuarkWallet.QuarkOperation memory) {
+        return newBasicOpWithCalldata(
+            wallet, scriptSource, scriptCalldata, ensureScripts, scriptType, semiRandomNonce(wallet)
+        );
+    }
+
+    function newBasicOpWithCalldata(
+        QuarkWallet wallet,
+        bytes memory scriptSource,
+        bytes memory scriptCalldata,
+        ScriptType scriptType,
+        bytes32 nonce
+    ) public returns (QuarkWallet.QuarkOperation memory) {
+        return newBasicOpWithCalldata(wallet, scriptSource, scriptCalldata, new bytes[](0), scriptType, nonce);
+    }
+
+    function newBasicOpWithCalldata(
+        QuarkWallet wallet,
+        bytes memory scriptSource,
+        bytes memory scriptCalldata,
+        bytes[] memory ensureScripts,
+        ScriptType scriptType,
+        bytes32 nonce
+    ) public returns (QuarkWallet.QuarkOperation memory) {
         address scriptAddress = wallet.codeJar().saveCode(scriptSource);
         if (scriptType == ScriptType.ScriptAddress) {
             return QuarkWallet.QuarkOperation({
                 scriptAddress: scriptAddress,
                 scriptSources: ensureScripts,
                 scriptCalldata: scriptCalldata,
-                nonce: semiRandomNonce(wallet),
+                nonce: nonce,
                 isReplayable: false,
                 expiry: block.timestamp + 1000
             });
@@ -54,7 +77,7 @@ contract QuarkOperationHelper is Test {
                 scriptAddress: scriptAddress,
                 scriptSources: ensureScripts,
                 scriptCalldata: scriptCalldata,
-                nonce: semiRandomNonce(wallet),
+                nonce: nonce,
                 isReplayable: false,
                 expiry: block.timestamp + 1000
             });
@@ -75,13 +98,39 @@ contract QuarkOperationHelper is Test {
         QuarkWallet wallet,
         bytes memory scriptSource,
         bytes memory scriptCalldata,
+        ScriptType scriptType,
+        uint256 replays,
+        bytes32 nonce
+    ) public returns (QuarkWallet.QuarkOperation memory, bytes32[] memory submissionTokens) {
+        return newReplayableOpWithCalldata(
+            wallet, scriptSource, scriptCalldata, new bytes[](0), scriptType, replays, nonce
+        );
+    }
+
+    function newReplayableOpWithCalldata(
+        QuarkWallet wallet,
+        bytes memory scriptSource,
+        bytes memory scriptCalldata,
         bytes[] memory ensureScripts,
         ScriptType scriptType,
         uint256 replays
     ) public returns (QuarkWallet.QuarkOperation memory, bytes32[] memory submissionTokens) {
+        return newReplayableOpWithCalldata(
+            wallet, scriptSource, scriptCalldata, ensureScripts, scriptType, replays, semiRandomNonce(wallet)
+        );
+    }
+
+    function newReplayableOpWithCalldata(
+        QuarkWallet wallet,
+        bytes memory scriptSource,
+        bytes memory scriptCalldata,
+        bytes[] memory ensureScripts,
+        ScriptType scriptType,
+        uint256 replays,
+        bytes32 nonce
+    ) public returns (QuarkWallet.QuarkOperation memory, bytes32[] memory submissionTokens) {
         QuarkWallet.QuarkOperation memory operation =
-            newBasicOpWithCalldata(wallet, scriptSource, scriptCalldata, ensureScripts, scriptType);
-        bytes32 nonce = operation.nonce;
+            newBasicOpWithCalldata(wallet, scriptSource, scriptCalldata, ensureScripts, scriptType, nonce);
         submissionTokens = new bytes32[](replays + 1);
         submissionTokens[replays] = nonce;
         for (uint256 i = 0; i < replays; i++) {
@@ -93,27 +142,35 @@ contract QuarkOperationHelper is Test {
         return (operation, submissionTokens);
     }
 
-    function cancelReplayable(QuarkWallet wallet, QuarkWallet.QuarkOperation memory quarkOperation)
+    function cancelReplayableByNop(QuarkWallet wallet, QuarkWallet.QuarkOperation memory quarkOperation)
         public
         returns (QuarkWallet.QuarkOperation memory)
     {
-        return cancelReplayable(wallet, quarkOperation, abi.encodeWithSignature("run()"));
+        return getCancelOperation(wallet, quarkOperation.nonce, abi.encodeWithSignature("nop()"));
     }
 
-    function cancelReplayable(
-        QuarkWallet wallet,
-        QuarkWallet.QuarkOperation memory quarkOperation,
-        bytes memory callData
-    ) public returns (QuarkWallet.QuarkOperation memory) {
-        bytes memory cancelOtherScript = new YulHelper().getCode("CancelOtherScript.sol/CancelOtherScript.json");
-        address scriptAddress = wallet.codeJar().saveCode(cancelOtherScript);
+    function cancelReplayableByNewOp(QuarkWallet wallet, QuarkWallet.QuarkOperation memory quarkOperation)
+        public
+        returns (QuarkWallet.QuarkOperation memory)
+    {
+        return getCancelOperation(
+            wallet, semiRandomNonce(wallet), abi.encodeWithSignature("cancel(bytes32)", quarkOperation.nonce)
+        );
+    }
+
+    function getCancelOperation(QuarkWallet wallet, bytes32 selfNonce, bytes memory callData)
+        public
+        returns (QuarkWallet.QuarkOperation memory)
+    {
+        bytes memory cancelScript = new YulHelper().getCode("Cancel.sol/Cancel.json");
+        address scriptAddress = wallet.codeJar().saveCode(cancelScript);
         bytes[] memory scriptSources = new bytes[](1);
-        scriptSources[0] = cancelOtherScript;
+        scriptSources[0] = cancelScript;
         return QuarkWallet.QuarkOperation({
             scriptAddress: scriptAddress,
             scriptSources: scriptSources,
             scriptCalldata: callData,
-            nonce: quarkOperation.nonce,
+            nonce: selfNonce,
             isReplayable: false,
             expiry: block.timestamp + 1000
         });

--- a/test/lib/RecurringPurchase.sol
+++ b/test/lib/RecurringPurchase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";

--- a/test/lib/Redeployer.sol
+++ b/test/lib/Redeployer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 interface CodeJar {
     function saveCode(bytes memory code) external returns (address);

--- a/test/lib/ReentrantTransfer.sol
+++ b/test/lib/ReentrantTransfer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";

--- a/test/lib/Reverts.sol
+++ b/test/lib/Reverts.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {CodeJar} from "codejar/src/CodeJar.sol";
 

--- a/test/lib/SignatureHelper.sol
+++ b/test/lib/SignatureHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "quark-core/src/QuarkWallet.sol";

--- a/test/lib/TickCounter.sol
+++ b/test/lib/TickCounter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 contract TickCounter {
     uint256 public immutable base;

--- a/test/lib/Transfer.sol
+++ b/test/lib/Transfer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";

--- a/test/lib/VictimERC777.sol
+++ b/test/lib/VictimERC777.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "openzeppelin/token/ERC777/ERC777.sol";
 import "openzeppelin/token/ERC20/ERC20.sol";

--- a/test/lib/Wacky.sol
+++ b/test/lib/Wacky.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 contract WackyBeacon {
     bytes public code;

--- a/test/lib/YulHelper.sol
+++ b/test/lib/YulHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 

--- a/test/quark-core-scripts/ConditionalMulticall.t.sol
+++ b/test/quark-core-scripts/ConditionalMulticall.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-core-scripts/Ethcall.t.sol
+++ b/test/quark-core-scripts/Ethcall.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-core-scripts/Multicall.t.sol
+++ b/test/quark-core-scripts/Multicall.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-core-scripts/Paycall.t.sol
+++ b/test/quark-core-scripts/Paycall.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-core-scripts/Quotecall.t.sol
+++ b/test/quark-core-scripts/Quotecall.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-core-scripts/UniswapFlashLoan.t.sol
+++ b/test/quark-core-scripts/UniswapFlashLoan.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-core-scripts/UniswapFlashSwapExactOut.t.sol
+++ b/test/quark-core-scripts/UniswapFlashSwapExactOut.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-core-scripts/interfaces/IComet.sol
+++ b/test/quark-core-scripts/interfaces/IComet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 interface IComet {
     function getAssetInfo(uint8 i) external view returns (AssetInfo memory);

--- a/test/quark-core-scripts/interfaces/ISwapRouter.sol
+++ b/test/quark-core-scripts/interfaces/ISwapRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 // Router interfaces thats only used in test for swapping
 interface ISwapRouter {

--- a/test/quark-core/Callbacks.t.sol
+++ b/test/quark-core/Callbacks.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/console.sol";
 
@@ -173,33 +173,59 @@ contract CallbacksTest is Test {
         assertEq(counter.number(), 2);
     }
 
-    function testClearCallback() public {
+    function testSimpleCallback() public {
         // gas: do not meter set-up
         vm.pauseGasMetering();
-        bytes32 callbackSlot = aliceWallet.CALLBACK_SLOT();
         bytes memory allowCallbacks = new YulHelper().getCode("AllowCallbacks.sol/AllowCallbacks.json");
 
         (QuarkWallet.QuarkOperation memory op1, bytes32[] memory submissionTokens) = new QuarkOperationHelper()
             .newReplayableOpWithCalldata(
-            aliceWallet, allowCallbacks, abi.encodeWithSignature("allowCallbackFun()"), ScriptType.ScriptSource, 1
+            aliceWallet, allowCallbacks, abi.encodeWithSignature("run()"), ScriptType.ScriptSource, 1
         );
         (uint8 v1, bytes32 r1, bytes32 s1) = new SignatureHelper().signOp(alicePrivateKey, aliceWallet, op1);
-        QuarkWallet.QuarkOperation memory op2 = new QuarkOperationHelper().newBasicOpWithCalldata(
-            aliceWallet, allowCallbacks, abi.encodeWithSignature("clearCallbackFun()"), ScriptType.ScriptSource
-        );
-        op2.nonce = op1.nonce;
-        (uint8 v2, bytes32 r2, bytes32 s2) = new SignatureHelper().signOp(alicePrivateKey, aliceWallet, op2);
-
-        assertEq(vm.load(address(aliceWallet), callbackSlot), bytes32(0));
 
         // gas: meter execute
         vm.resumeGasMetering();
+        bytes memory result = aliceWallet.executeQuarkOperation(op1, v1, r1, s1);
+        uint256 res = abi.decode(result, (uint256));
+        assertEq(res, 202);
+
+        // Can run again
+        result = aliceWallet.executeQuarkOperationWithSubmissionToken(op1, submissionTokens[1], v1, r1, s1);
+        res = abi.decode(result, (uint256));
+        assertEq(res, 204);
+    }
+
+    function testWithoutAllowCallback() public {
+        // gas: do not meter set-up
+        vm.pauseGasMetering();
+        bytes memory allowCallbacks = new YulHelper().getCode("AllowCallbacks.sol/AllowCallbacks.json");
+
+        (QuarkWallet.QuarkOperation memory op1,) = new QuarkOperationHelper().newReplayableOpWithCalldata(
+            aliceWallet, allowCallbacks, abi.encodeWithSignature("runWithoutAllow()"), ScriptType.ScriptSource, 1
+        );
+        (uint8 v1, bytes32 r1, bytes32 s1) = new SignatureHelper().signOp(alicePrivateKey, aliceWallet, op1);
+
+        // gas: meter execute
+        vm.resumeGasMetering();
+        vm.expectRevert(abi.encodeWithSelector(QuarkWallet.NoActiveCallback.selector));
         aliceWallet.executeQuarkOperation(op1, v1, r1, s1);
+    }
 
-        assertNotEq(vm.load(address(aliceWallet), callbackSlot), bytes32(0));
+    function testWithClearedCallback() public {
+        // gas: do not meter set-up
+        vm.pauseGasMetering();
+        bytes memory allowCallbacks = new YulHelper().getCode("AllowCallbacks.sol/AllowCallbacks.json");
 
-        aliceWallet.executeQuarkOperationWithSubmissionToken(op2, submissionTokens[1], v2, r2, s2);
-        assertEq(vm.load(address(aliceWallet), callbackSlot), bytes32(0));
+        (QuarkWallet.QuarkOperation memory op1,) = new QuarkOperationHelper().newReplayableOpWithCalldata(
+            aliceWallet, allowCallbacks, abi.encodeWithSignature("runAllowThenClear()"), ScriptType.ScriptSource, 1
+        );
+        (uint8 v1, bytes32 r1, bytes32 s1) = new SignatureHelper().signOp(alicePrivateKey, aliceWallet, op1);
+
+        // gas: meter execute
+        vm.resumeGasMetering();
+        vm.expectRevert(abi.encodeWithSelector(QuarkWallet.NoActiveCallback.selector));
+        aliceWallet.executeQuarkOperation(op1, v1, r1, s1);
     }
 
     function testRevertsOnCallbackWhenNoActiveCallback() public {

--- a/test/quark-core/EIP1271.t.sol
+++ b/test/quark-core/EIP1271.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/StdUtils.sol";

--- a/test/quark-core/EIP712.t.sol
+++ b/test/quark-core/EIP712.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/StdUtils.sol";

--- a/test/quark-core/Executor.t.sol
+++ b/test/quark-core/Executor.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/console.sol";
 

--- a/test/quark-core/QuarkNonceManager.t.sol
+++ b/test/quark-core/QuarkNonceManager.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
@@ -41,10 +41,10 @@ contract QuarkNonceManagerTest is Test {
     function testNonceOneIsValid() public {
         bytes32 nonce = bytes32(uint256(1));
 
-        // by default, nonce 0 is not set
+        // by default, nonce 1 is not set
         assertEq(nonceManager.submissions(address(0x123), nonce), nonceManager.FREE());
 
-        // nonce 0 can be set manually
+        // nonce 1 can be set manually
         vm.prank(address(0x123));
         nonceManager.submit(nonce, false, nonce);
         assertEq(nonceManager.submissions(address(0x123), nonce), nonceManager.EXHAUSTED());
@@ -226,26 +226,25 @@ contract QuarkNonceManagerTest is Test {
         // nonce values are not incremental; you can use a random number as
         // long as it has not been set
         bytes32 nonceSecret = bytes32(uint256(99));
-        bytes32 replayToken2 = keccak256(abi.encodePacked(nonceSecret));
-        bytes32 replayToken1 = keccak256(abi.encodePacked(replayToken2));
-        bytes32 rootHash = keccak256(abi.encodePacked(replayToken1));
-        bytes32 nonce = rootHash;
+        bytes32 submissionToken2 = keccak256(abi.encodePacked(nonceSecret));
+        bytes32 submissionToken1 = keccak256(abi.encodePacked(submissionToken2));
+        bytes32 nonce = keccak256(abi.encodePacked(submissionToken1));
 
         assertEq(nonceManager.submissions(address(this), nonce), FREE_TOKEN);
 
-        nonceManager.submit(nonce, true, rootHash);
-        assertEq(nonceManager.submissions(address(this), nonce), rootHash);
+        nonceManager.submit(nonce, true, nonce);
+        assertEq(nonceManager.submissions(address(this), nonce), nonce);
 
         vm.expectRevert(
-            abi.encodeWithSelector(QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, rootHash)
+            abi.encodeWithSelector(QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, nonce)
         );
-        nonceManager.submit(nonce, true, rootHash);
+        nonceManager.submit(nonce, true, nonce);
         vm.expectRevert(
             abi.encodeWithSelector(
-                QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, replayToken2
+                QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, submissionToken2
             )
         );
-        nonceManager.submit(nonce, true, replayToken2);
+        nonceManager.submit(nonce, true, submissionToken2);
         vm.expectRevert(
             abi.encodeWithSelector(QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, nonceSecret)
         );
@@ -261,19 +260,19 @@ contract QuarkNonceManagerTest is Test {
         );
         nonceManager.submit(nonce, true, EXHAUSTED_TOKEN);
 
-        nonceManager.submit(nonce, true, replayToken1);
-        assertEq(nonceManager.submissions(address(this), nonce), replayToken1);
+        nonceManager.submit(nonce, true, submissionToken1);
+        assertEq(nonceManager.submissions(address(this), nonce), submissionToken1);
 
         vm.expectRevert(
-            abi.encodeWithSelector(QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, rootHash)
+            abi.encodeWithSelector(QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, nonce)
         );
-        nonceManager.submit(nonce, true, rootHash);
+        nonceManager.submit(nonce, true, nonce);
         vm.expectRevert(
             abi.encodeWithSelector(
-                QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, replayToken1
+                QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, submissionToken1
             )
         );
-        nonceManager.submit(nonce, true, replayToken1);
+        nonceManager.submit(nonce, true, submissionToken1);
         vm.expectRevert(
             abi.encodeWithSelector(QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, nonceSecret)
         );
@@ -289,25 +288,25 @@ contract QuarkNonceManagerTest is Test {
         );
         nonceManager.submit(nonce, true, EXHAUSTED_TOKEN);
 
-        nonceManager.submit(nonce, true, replayToken2);
-        assertEq(nonceManager.submissions(address(this), nonce), replayToken2);
+        nonceManager.submit(nonce, true, submissionToken2);
+        assertEq(nonceManager.submissions(address(this), nonce), submissionToken2);
 
         vm.expectRevert(
-            abi.encodeWithSelector(QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, rootHash)
+            abi.encodeWithSelector(QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, nonce)
         );
-        nonceManager.submit(nonce, true, rootHash);
+        nonceManager.submit(nonce, true, nonce);
         vm.expectRevert(
             abi.encodeWithSelector(
-                QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, replayToken1
+                QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, submissionToken1
             )
         );
-        nonceManager.submit(nonce, true, replayToken1);
+        nonceManager.submit(nonce, true, submissionToken1);
         vm.expectRevert(
             abi.encodeWithSelector(
-                QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, replayToken2
+                QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, submissionToken2
             )
         );
-        nonceManager.submit(nonce, true, replayToken2);
+        nonceManager.submit(nonce, true, submissionToken2);
         vm.expectRevert(
             abi.encodeWithSelector(QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, FREE_TOKEN)
         );
@@ -323,21 +322,21 @@ contract QuarkNonceManagerTest is Test {
         assertEq(nonceManager.submissions(address(this), nonce), nonceSecret);
 
         vm.expectRevert(
-            abi.encodeWithSelector(QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, rootHash)
+            abi.encodeWithSelector(QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, nonce)
         );
-        nonceManager.submit(nonce, true, rootHash);
+        nonceManager.submit(nonce, true, nonce);
         vm.expectRevert(
             abi.encodeWithSelector(
-                QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, replayToken1
+                QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, submissionToken1
             )
         );
-        nonceManager.submit(nonce, true, replayToken1);
+        nonceManager.submit(nonce, true, submissionToken1);
         vm.expectRevert(
             abi.encodeWithSelector(
-                QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, replayToken2
+                QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, submissionToken2
             )
         );
-        nonceManager.submit(nonce, true, replayToken2);
+        nonceManager.submit(nonce, true, submissionToken2);
         vm.expectRevert(
             abi.encodeWithSelector(QuarkNonceManager.InvalidSubmissionToken.selector, address(this), nonce, nonceSecret)
         );
@@ -352,5 +351,91 @@ contract QuarkNonceManagerTest is Test {
             )
         );
         nonceManager.submit(nonce, true, EXHAUSTED_TOKEN);
+    }
+
+    function testCancelChain() public {
+        bytes32 nonceSecret = bytes32(uint256(99));
+        bytes32 submissionToken2 = keccak256(abi.encodePacked(nonceSecret));
+        bytes32 submissionToken1 = keccak256(abi.encodePacked(submissionToken2));
+        bytes32 nonce = keccak256(abi.encodePacked(submissionToken1));
+
+        assertEq(nonceManager.submissions(address(this), nonce), FREE_TOKEN);
+
+        nonceManager.submit(nonce, true, nonce);
+        assertEq(nonceManager.submissions(address(this), nonce), nonce);
+
+        nonceManager.cancel(nonce);
+        assertEq(nonceManager.submissions(address(this), nonce), EXHAUSTED_TOKEN);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, nonce, true)
+        );
+        nonceManager.submit(nonce, true, nonce);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, submissionToken2, true
+            )
+        );
+        nonceManager.submit(nonce, true, submissionToken2);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, submissionToken1, true
+            )
+        );
+        nonceManager.submit(nonce, true, submissionToken1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, nonceSecret, true
+            )
+        );
+        nonceManager.submit(nonce, true, nonceSecret);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, EXHAUSTED_TOKEN, true
+            )
+        );
+        nonceManager.submit(nonce, true, EXHAUSTED_TOKEN);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, FREE_TOKEN, true
+            )
+        );
+        nonceManager.submit(nonce, true, FREE_TOKEN);
+    }
+
+    function testPrecancelNonce() public {
+        bytes32 nonce = bytes32(uint256(1));
+
+        vm.prank(address(0x123));
+        nonceManager.cancel(nonce);
+
+        // by default, nonce 1 is not set
+        assertEq(nonceManager.submissions(address(0x123), nonce), nonceManager.EXHAUSTED());
+
+        // nonce 1 can be set manually
+        vm.prank(address(0x123));
+        vm.expectRevert(
+            abi.encodeWithSelector(QuarkNonceManager.NonReplayableNonce.selector, address(0x123), nonce, nonce, true)
+        );
+        nonceManager.submit(nonce, false, nonce);
+        assertEq(nonceManager.submissions(address(0x123), nonce), nonceManager.EXHAUSTED());
+    }
+
+    function testCancelExhaustedIsNoOp() public {
+        bytes32 nonce = bytes32(uint256(1));
+
+        // by default, nonce 1 is not set
+        assertEq(nonceManager.submissions(address(0x123), nonce), nonceManager.FREE());
+
+        // nonce 1 can be set manually
+        vm.prank(address(0x123));
+        nonceManager.submit(nonce, false, nonce);
+        assertEq(nonceManager.submissions(address(0x123), nonce), nonceManager.EXHAUSTED());
+
+        vm.prank(address(0x123));
+        nonceManager.cancel(nonce);
+
+        assertEq(nonceManager.submissions(address(0x123), nonce), nonceManager.EXHAUSTED());
     }
 }

--- a/test/quark-core/QuarkWallet.t.sol
+++ b/test/quark-core/QuarkWallet.t.sol
@@ -235,7 +235,6 @@ contract QuarkWalletTest is Test {
         // gas: do not meter set-up
         vm.pauseGasMetering();
 
-        Counter counter = new Counter();
         assertEq(counter.number(), 0);
 
         bytes memory maxCounterScript = new YulHelper().getCode("MaxCounterScript.sol/MaxCounterScript.json");

--- a/test/quark-core/Reverts.t.sol
+++ b/test/quark-core/Reverts.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-core/isValidSignature.t.sol
+++ b/test/quark-core/isValidSignature.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/StdUtils.sol";

--- a/test/quark-core/periphery/BatchExecutor.t.sol
+++ b/test/quark-core/periphery/BatchExecutor.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-factory/QuarkFactory.t.sol
+++ b/test/quark-factory/QuarkFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-proxy/QuarkMinimalProxy.t.sol
+++ b/test/quark-proxy/QuarkMinimalProxy.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/console.sol";
 import {Test} from "forge-std/Test.sol";

--- a/test/quark-proxy/QuarkWalletProxyFactory.t.sol
+++ b/test/quark-proxy/QuarkWalletProxyFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";


### PR DESCRIPTION
This patch uses library values for a variety of constants as a way to clean up a variety of copy-pasted code in our QuarkScripts code. Small clean-up.