### PR TITLE
TStore for Transients

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
-solc = "0.8.23"
-evm_version = "paris"
+solc = "0.8.27"
+evm_version = "cancun"
 
 libs = [ "./lib" ]
 

--- a/script/DeployCodeJarFactory.s.sol
+++ b/script/DeployCodeJarFactory.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Script.sol";
 import "forge-std/console.sol";

--- a/script/DeployQuarkWalletFactory.s.sol
+++ b/script/DeployQuarkWalletFactory.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Script.sol";
 import "forge-std/console.sol";

--- a/src/codejar/foundry.toml
+++ b/src/codejar/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
-solc = "0.8.23"
-evm_version = "paris"
+solc = "0.8.27"
+evm_version = "cancun"
 
 libs = [ "../../lib" ]
 

--- a/src/codejar/src/CodeJar.sol
+++ b/src/codejar/src/CodeJar.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 /**
  * @title Code Jar

--- a/src/codejar/src/CodeJarFactory.sol
+++ b/src/codejar/src/CodeJarFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {CodeJar} from "codejar/src/CodeJar.sol";
 

--- a/src/quark-core-scripts/foundry.toml
+++ b/src/quark-core-scripts/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
-solc = "0.8.23"
-evm_version = "paris"
+solc = "0.8.27"
+evm_version = "cancun"
 
 libs = [ "../../lib" ]
 

--- a/src/quark-core-scripts/src/Cancel.sol
+++ b/src/quark-core-scripts/src/Cancel.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.27;
+
+import {IQuarkWallet} from "quark-core/src/QuarkWallet.sol";
+import {QuarkNonceManager} from "quark-core/src/QuarkNonceManager.sol";
+
+/**
+ * @title Cancel Core Script
+ * @notice Core transaction script that can be used to cancel quark operations.
+ * @author Legend Labs, Inc.
+ */
+contract Cancel {
+    /**
+     * @notice May cancel a script by being run as a no-op (no operation).
+     */
+    function nop() external pure {}
+
+    /**
+     * @notice Cancels a script by calling into nonce manager to cancel the script's nonce.
+     * @param nonce The nonce of the quark operation to cancel (exhaust)
+     */
+    function cancel(bytes32 nonce) external {
+        nonceManager().cancel(nonce);
+    }
+
+    /**
+     * @notice Cancels many scripts by calling into nonce manager to cancel each script's nonce.
+     * @param nonces A list of nonces of the quark operations to cancel (exhaust)
+     */
+    function cancelMany(bytes32[] calldata nonces) external {
+        QuarkNonceManager manager = nonceManager();
+        for (uint256 i = 0; i < nonces.length; ++i) {
+            bytes32 nonce = nonces[i];
+            manager.cancel(nonce);
+        }
+    }
+
+    function nonceManager() internal view returns (QuarkNonceManager) {
+        return QuarkNonceManager(IQuarkWallet(address(this)).nonceManager());
+    }
+}

--- a/src/quark-core-scripts/src/ConditionalMulticall.sol
+++ b/src/quark-core-scripts/src/ConditionalMulticall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "quark-core-scripts/src/lib/ConditionalChecker.sol";
 

--- a/src/quark-core-scripts/src/Ethcall.sol
+++ b/src/quark-core-scripts/src/Ethcall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 /**
  * @title Ethcall Core Script

--- a/src/quark-core-scripts/src/Multicall.sol
+++ b/src/quark-core-scripts/src/Multicall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 /**
  * @title Multicall Core Script

--- a/src/quark-core-scripts/src/Paycall.sol
+++ b/src/quark-core-scripts/src/Paycall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "quark-core-scripts/src/vendor/chainlink/AggregatorV3Interface.sol";
 import "openzeppelin/token/ERC20/utils/SafeERC20.sol";

--- a/src/quark-core-scripts/src/Quotecall.sol
+++ b/src/quark-core-scripts/src/Quotecall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "quark-core-scripts/src/vendor/chainlink/AggregatorV3Interface.sol";
 import "openzeppelin/token/ERC20/utils/SafeERC20.sol";

--- a/src/quark-core-scripts/src/UniswapFlashLoan.sol
+++ b/src/quark-core-scripts/src/UniswapFlashLoan.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "openzeppelin/token/ERC20/utils/SafeERC20.sol";
 import "v3-core/contracts/interfaces/IUniswapV3Pool.sol";

--- a/src/quark-core-scripts/src/UniswapFlashSwapExactOut.sol
+++ b/src/quark-core-scripts/src/UniswapFlashSwapExactOut.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "openzeppelin/token/ERC20/utils/SafeERC20.sol";
 import "v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.sol";

--- a/src/quark-core-scripts/src/lib/ConditionalChecker.sol
+++ b/src/quark-core-scripts/src/lib/ConditionalChecker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 library ConditionalChecker {
     enum CheckType {

--- a/src/quark-core-scripts/src/lib/UniswapFactoryAddress.sol
+++ b/src/quark-core-scripts/src/lib/UniswapFactoryAddress.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 library UniswapFactoryAddress {
     // Reference: https://docs.uniswap.org/contracts/v3/reference/deployments

--- a/src/quark-core-scripts/src/vendor/manifest.json
+++ b/src/quark-core-scripts/src/vendor/manifest.json
@@ -16,7 +16,7 @@
                     "newLines": 6,
                     "lines": [
                         " // SPDX-License-Identifier: GPL-2.0-or-later",
-                        "-pragma solidity 0.8.23;",
+                        "-pragma solidity 0.8.27;",
                         "+pragma solidity >=0.5.0;",
                         " ",
                         " /// @title Provides functions for deriving a pool address from the factory, tokens, and the fee",

--- a/src/quark-core-scripts/src/vendor/uniswap_v3_periphery/PoolAddress.sol
+++ b/src/quark-core-scripts/src/vendor/uniswap_v3_periphery/PoolAddress.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 /// @title Provides functions for deriving a pool address from the factory, tokens, and the fee
 library PoolAddress {

--- a/src/quark-core/foundry.toml
+++ b/src/quark-core/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
-solc = "0.8.23"
-evm_version = "paris"
+solc = "0.8.27"
+evm_version = "cancun"
 
 libs = [ "../../lib" ]
 

--- a/src/quark-core/src/QuarkNonceManager.sol
+++ b/src/quark-core/src/QuarkNonceManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {IQuarkWallet} from "quark-core/src/interfaces/IQuarkWallet.sol";
 

--- a/src/quark-core/src/QuarkScript.sol
+++ b/src/quark-core/src/QuarkScript.sol
@@ -114,8 +114,6 @@ abstract contract QuarkScript {
         return write(keccak256(bytes(key)), value);
     }
 
-    // TODO: Consider adding nonce-based scoping by TLOAD'ing the nonce and using
-    // that to hash the key.
     function write(bytes32 key, bytes32 value) internal {
         bytes32 isolatedKey = getNonceIsolatedKey(key);
         assembly {

--- a/src/quark-core/src/QuarkScript.sol
+++ b/src/quark-core/src/QuarkScript.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {QuarkWallet, QuarkWalletMetadata, IHasSignerExecutor, IQuarkWallet} from "quark-core/src/QuarkWallet.sol";
 import {QuarkNonceManager, QuarkNonceManagerMetadata} from "quark-core/src/QuarkNonceManager.sol";
@@ -23,21 +23,20 @@ abstract contract QuarkScript {
     modifier nonReentrant() {
         bytes32 slot = REENTRANCY_FLAG_SLOT;
         bytes32 flag;
-        // TODO: Move to TSTORE after updating Solidity version to >=0.8.24
         assembly {
-            flag := sload(slot)
+            flag := tload(slot)
         }
         if (flag == bytes32(uint256(1))) {
             revert ReentrantCall();
         }
         assembly {
-            sstore(slot, 1)
+            tstore(slot, 1)
         }
 
         _;
 
         assembly {
-            sstore(slot, 0)
+            tstore(slot, 0)
         }
     }
 
@@ -78,17 +77,15 @@ abstract contract QuarkScript {
         bytes32 callbackSlot = QuarkWalletMetadata.CALLBACK_SLOT;
         bytes32 activeScriptSlot = QuarkWalletMetadata.ACTIVE_SCRIPT_SLOT;
         assembly {
-            // TODO: Move to TLOAD/TSTORE after updating Solidity version to >=0.8.24
-            let activeScript := sload(activeScriptSlot)
-            sstore(callbackSlot, activeScript)
+            let activeScript := tload(activeScriptSlot)
+            tstore(callbackSlot, activeScript)
         }
     }
 
     function clearCallback() internal {
         bytes32 callbackSlot = QuarkWalletMetadata.CALLBACK_SLOT;
         assembly {
-            // TODO: Move to TSTORE after updating Solidity version to >=0.8.24
-            sstore(callbackSlot, 0)
+            tstore(callbackSlot, 0)
         }
     }
 
@@ -141,7 +138,7 @@ abstract contract QuarkScript {
         bytes32 activeNonceSlot = QuarkWalletMetadata.ACTIVE_NONCE_SLOT;
         bytes32 value;
         assembly {
-            value := sload(activeNonceSlot)
+            value := tload(activeNonceSlot)
         }
 
         return value;
@@ -152,7 +149,7 @@ abstract contract QuarkScript {
         bytes32 activeSubmissionTokenSlot = QuarkWalletMetadata.ACTIVE_SUBMISSION_TOKEN_SLOT;
         bytes32 value;
         assembly {
-            value := sload(activeSubmissionTokenSlot)
+            value := tload(activeSubmissionTokenSlot)
         }
         return value;
     }

--- a/src/quark-core/src/QuarkWallet.sol
+++ b/src/quark-core/src/QuarkWallet.sol
@@ -78,11 +78,12 @@ contract QuarkWallet is IERC1271 {
     }
 
     /// @notice Event emitted when a Quark script is executed by this Quark wallet
-    event ExecuteQuarkScript(
+    event QuarkExecution(
         address indexed executor,
         address indexed scriptAddress,
         bytes32 indexed nonce,
         bytes32 submissionToken,
+        bool isReplayable,
         ExecutionType executionType
     );
 
@@ -292,7 +293,9 @@ contract QuarkWallet is IERC1271 {
 
         nonceManager.submit(op.nonce, op.isReplayable, submissionToken);
 
-        emit ExecuteQuarkScript(msg.sender, op.scriptAddress, op.nonce, submissionToken, ExecutionType.Signature);
+        emit QuarkExecution(
+            msg.sender, op.scriptAddress, op.nonce, submissionToken, op.isReplayable, ExecutionType.Signature
+        );
 
         return executeScriptInternal(op.scriptAddress, op.scriptCalldata, op.nonce, submissionToken);
     }
@@ -324,7 +327,7 @@ contract QuarkWallet is IERC1271 {
 
         nonceManager.submit(nonce, false, nonce);
 
-        emit ExecuteQuarkScript(msg.sender, scriptAddress, nonce, nonce, ExecutionType.Direct);
+        emit QuarkExecution(msg.sender, scriptAddress, nonce, nonce, false, ExecutionType.Direct);
 
         return executeScriptInternal(scriptAddress, scriptCalldata, nonce, nonce);
     }

--- a/src/quark-core/src/QuarkWallet.sol
+++ b/src/quark-core/src/QuarkWallet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {ECDSA} from "openzeppelin/utils/cryptography/ECDSA.sol";
 import {IERC1271} from "openzeppelin/interfaces/IERC1271.sol";
@@ -482,31 +482,28 @@ contract QuarkWallet is IERC1271 {
         assembly {
             // TODO: TSTORE the callback slot to 0
 
-            // Store the active script
-            // TODO: Move to TSTORE after updating Solidity version to >=0.8.24
-            sstore(activeScriptSlot, scriptAddress)
+            // Transiently store the active script
+            tstore(activeScriptSlot, scriptAddress)
 
-            // Store the active nonce
-            // TODO: Move to TSTORE after updating Solidity version to >=0.8.24
-            sstore(activeNonceSlot, nonce)
+            // Transiently store the active nonce
+            tstore(activeNonceSlot, nonce)
 
-            // Store the active submission token
-            // TODO: Move to TSTORE after updating Solidity version to >=0.8.24
-            sstore(activeSubmissionTokenSlot, submissionToken)
+            // Transiently store the active submission token
+            tstore(activeSubmissionTokenSlot, submissionToken)
 
             // Note: CALLCODE is used to set the QuarkWallet as the `msg.sender`
             success :=
                 callcode(gas(), scriptAddress, /* value */ 0, add(scriptCalldata, 0x20), scriptCalldataLen, 0x0, 0)
             returnSize := returndatasize()
 
-            // TODO: Move to TSTORE after updating Solidity version to >=0.8.24
-            sstore(activeScriptSlot, 0)
+            // Transiently clear the active script
+            tstore(activeScriptSlot, 0)
 
-            // TODO: Move to TSTORE after updating Solidity version to >=0.8.24
-            sstore(activeNonceSlot, 0)
+            // Transiently clear the active nonce
+            tstore(activeNonceSlot, 0)
 
-            // TODO: Move to TSTORE after updating Solidity version to >=0.8.24
-            sstore(activeSubmissionTokenSlot, 0)
+            // Transiently clear the active submission token
+            tstore(activeSubmissionTokenSlot, 0)
         }
 
         bytes memory returnData = new bytes(returnSize);
@@ -531,8 +528,7 @@ contract QuarkWallet is IERC1271 {
         bytes32 callbackSlot = CALLBACK_SLOT;
         address callback;
         assembly {
-            // TODO: Move to TLOAD after updating Solidity version to >=0.8.24
-            callback := sload(callbackSlot)
+            callback := tload(callbackSlot)
         }
         if (callback != address(0)) {
             (bool success, bytes memory result) = callback.delegatecall(data);

--- a/src/quark-core/src/QuarkWalletStandalone.sol
+++ b/src/quark-core/src/QuarkWalletStandalone.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {CodeJar} from "codejar/src/CodeJar.sol";
 

--- a/src/quark-core/src/interfaces/IHasSignerExecutor.sol
+++ b/src/quark-core/src/interfaces/IHasSignerExecutor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 /**
  * @title Has Signer and Executor interface

--- a/src/quark-core/src/interfaces/IQuarkWallet.sol
+++ b/src/quark-core/src/interfaces/IQuarkWallet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 /**
  * @title Quark Wallet interface

--- a/src/quark-core/src/periphery/BatchExecutor.sol
+++ b/src/quark-core/src/periphery/BatchExecutor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {QuarkWallet} from "quark-core/src/QuarkWallet.sol";
 

--- a/src/quark-factory/foundry.toml
+++ b/src/quark-factory/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
-solc = "0.8.23"
-evm_version = "paris"
+solc = "0.8.27"
+evm_version = "cancun"
 
 libs = [ "../../lib" ]
 

--- a/src/quark-factory/src/QuarkFactory.sol
+++ b/src/quark-factory/src/QuarkFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {CodeJar} from "codejar/src/CodeJar.sol";
 import {QuarkWallet} from "quark-core/src/QuarkWallet.sol";

--- a/src/quark-proxy/foundry.toml
+++ b/src/quark-proxy/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
-solc = "0.8.23"
-evm_version = "paris"
+solc = "0.8.27"
+evm_version = "cancun"
 
 libs = [ "../../lib" ]
 

--- a/src/quark-proxy/src/QuarkMinimalProxy.sol
+++ b/src/quark-proxy/src/QuarkMinimalProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {IHasSignerExecutor} from "quark-core/src/interfaces/IHasSignerExecutor.sol";
 

--- a/src/quark-proxy/src/QuarkWalletProxyFactory.sol
+++ b/src/quark-proxy/src/QuarkWalletProxyFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {QuarkWallet, QuarkWalletMetadata} from "quark-core/src/QuarkWallet.sol";
 

--- a/test/ReplayableTransactions.t.sol
+++ b/test/ReplayableTransactions.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/codejar/CodeJar.t.sol
+++ b/test/codejar/CodeJar.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/lib/AllowCallbacks.sol
+++ b/test/lib/AllowCallbacks.sol
@@ -1,24 +1,36 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "quark-core/src/QuarkScript.sol";
 import "quark-core/src/QuarkWallet.sol";
 
+interface IComeback {
+    function request() external returns (uint256);
+}
+
+contract Comebacker {
+    function comeback() public returns (uint256) {
+        return IComeback(msg.sender).request() + 1;
+    }
+}
+
 contract AllowCallbacks is QuarkScript {
-    function run(address callbackAddress) public {
-        QuarkWallet self = QuarkWallet(payable(address(this)));
-        bytes32 CALLBACK_SLOT = self.CALLBACK_SLOT();
-        bytes32 data = bytes32(uint256(uint160(callbackAddress)));
-        assembly {
-            sstore(CALLBACK_SLOT, data)
-        }
-    }
-
-    function allowCallbackFun() public {
+    function run() public returns (uint256) {
         allowCallback();
+        return new Comebacker().comeback() * 2;
     }
 
-    function clearCallbackFun() public {
+    function runAllowThenClear() public returns (uint256) {
+        allowCallback();
         clearCallback();
+        return new Comebacker().comeback() * 2;
+    }
+
+    function runWithoutAllow() public returns (uint256) {
+        return new Comebacker().comeback() * 2;
+    }
+
+    function request() external view returns (uint256) {
+        return 100 + getActiveReplayCount();
     }
 }

--- a/test/lib/CallbackFromCounter.sol
+++ b/test/lib/CallbackFromCounter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "test/lib/Counter.sol";
 import "quark-core/src/QuarkScript.sol";

--- a/test/lib/CallcodeReentrancy.sol
+++ b/test/lib/CallcodeReentrancy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/console.sol";
 

--- a/test/lib/CancelOtherScript.sol
+++ b/test/lib/CancelOtherScript.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "quark-core/src/QuarkWallet.sol";
 import "quark-core/src/QuarkScript.sol";

--- a/test/lib/CheckNonceScript.sol
+++ b/test/lib/CheckNonceScript.sol
@@ -4,19 +4,7 @@ pragma solidity 0.8.27;
 import "quark-core/src/QuarkWallet.sol";
 import "quark-core/src/QuarkScript.sol";
 
-contract CancelOtherScript is QuarkScript {
-    event Nop();
-    event CancelNonce(bytes32 nonce);
-
-    function nop() public {
-        emit Nop();
-    }
-
-    function run(bytes32 nonce) public {
-        nonceManager().cancel(nonce);
-        emit CancelNonce(nonce);
-    }
-
+contract CheckNonceScript is QuarkScript {
     function checkNonce() public view returns (bytes32) {
         return getActiveNonce();
     }

--- a/test/lib/ConstructorReverter.sol
+++ b/test/lib/ConstructorReverter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 contract ConstructorReverter {
     error Test(uint256);

--- a/test/lib/Counter.sol
+++ b/test/lib/Counter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 interface HasCallback {
     function callback() external payable;

--- a/test/lib/CounterScript.sol
+++ b/test/lib/CounterScript.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "test/lib/Counter.sol";
 

--- a/test/lib/DeFiScripts.sol
+++ b/test/lib/DeFiScripts.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";

--- a/test/lib/EIP1271Signer.sol
+++ b/test/lib/EIP1271Signer.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 contract EIP1271Signer {
     bytes4 internal constant EIP_1271_MAGIC_VALUE = 0x1626ba7e;

--- a/test/lib/EmptyCode.sol
+++ b/test/lib/EmptyCode.sol
@@ -1,4 +1,4 @@
-pragma solidity "0.8.23";
+pragma solidity "0.8.27";
 
 contract EmptyCode {
     // NOTE: force the solidity compiler to produce empty code when this is deployed

--- a/test/lib/EvilReceiver.sol
+++ b/test/lib/EvilReceiver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "quark-core/src/QuarkWallet.sol";
 import "quark-core/src/QuarkScript.sol";

--- a/test/lib/ExecuteOnBehalf.sol
+++ b/test/lib/ExecuteOnBehalf.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "quark-core/src/QuarkWallet.sol";
 

--- a/test/lib/ExecuteOtherOperation.sol
+++ b/test/lib/ExecuteOtherOperation.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "quark-core/src/QuarkWallet.sol";
 import "quark-core/src/QuarkScript.sol";

--- a/test/lib/ExecuteWithRequirements.sol
+++ b/test/lib/ExecuteWithRequirements.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "quark-core/src/QuarkWallet.sol";
 import "quark-core/src/QuarkNonceManager.sol";

--- a/test/lib/GetMessageDetails.sol
+++ b/test/lib/GetMessageDetails.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 contract GetMessageDetails {
     function getMsgSenderAndValue() external payable returns (address, uint256) {

--- a/test/lib/Incrementer.sol
+++ b/test/lib/Incrementer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "test/lib/Counter.sol";
 

--- a/test/lib/Logger.sol
+++ b/test/lib/Logger.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 contract Logger {
     event Ping(uint256);

--- a/test/lib/MaxCounterScript.sol
+++ b/test/lib/MaxCounterScript.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "quark-core/src/QuarkScript.sol";
 import "test/lib/Counter.sol";

--- a/test/lib/Mememe.sol
+++ b/test/lib/Mememe.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 contract Mememe {
     address public immutable me;

--- a/test/lib/Noncer.sol
+++ b/test/lib/Noncer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {QuarkScript} from "quark-core/src/QuarkScript.sol";
 import {QuarkWallet} from "quark-core/src/QuarkWallet.sol";

--- a/test/lib/Permit2Helper.sol
+++ b/test/lib/Permit2Helper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 interface Permit2 {
     function permit(address owner, Permit2Helper.PermitSingle memory permitSingle, bytes calldata signature) external;

--- a/test/lib/PrecompileCaller.sol
+++ b/test/lib/PrecompileCaller.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 contract PrecompileCaller {
     // 0x01

--- a/test/lib/QuarkOperationHelper.sol
+++ b/test/lib/QuarkOperationHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "quark-core/src/QuarkWallet.sol";

--- a/test/lib/QuarkOperationHelper.sol
+++ b/test/lib/QuarkOperationHelper.sol
@@ -48,6 +48,16 @@ contract QuarkOperationHelper is Test {
         QuarkWallet wallet,
         bytes memory scriptSource,
         bytes memory scriptCalldata,
+        ScriptType scriptType,
+        bytes32 nonce
+    ) public returns (QuarkWallet.QuarkOperation memory) {
+        return newBasicOpWithCalldata(wallet, scriptSource, scriptCalldata, new bytes[](0), scriptType, nonce);
+    }
+
+    function newBasicOpWithCalldata(
+        QuarkWallet wallet,
+        bytes memory scriptSource,
+        bytes memory scriptCalldata,
         bytes[] memory ensureScripts,
         ScriptType scriptType,
         bytes32 nonce
@@ -144,7 +154,7 @@ contract QuarkOperationHelper is Test {
         returns (QuarkWallet.QuarkOperation memory)
     {
         return getCancelOperation(
-            wallet, semiRandomNonce(wallet), abi.encodeWithSignature("run(bytes32)", quarkOperation.nonce)
+            wallet, semiRandomNonce(wallet), abi.encodeWithSignature("cancel(bytes32)", quarkOperation.nonce)
         );
     }
 
@@ -152,10 +162,10 @@ contract QuarkOperationHelper is Test {
         public
         returns (QuarkWallet.QuarkOperation memory)
     {
-        bytes memory cancelOtherScript = new YulHelper().getCode("CancelOtherScript.sol/CancelOtherScript.json");
-        address scriptAddress = wallet.codeJar().saveCode(cancelOtherScript);
+        bytes memory cancelScript = new YulHelper().getCode("Cancel.sol/Cancel.json");
+        address scriptAddress = wallet.codeJar().saveCode(cancelScript);
         bytes[] memory scriptSources = new bytes[](1);
-        scriptSources[0] = cancelOtherScript;
+        scriptSources[0] = cancelScript;
         return QuarkWallet.QuarkOperation({
             scriptAddress: scriptAddress,
             scriptSources: scriptSources,

--- a/test/lib/RecurringPurchase.sol
+++ b/test/lib/RecurringPurchase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";

--- a/test/lib/Redeployer.sol
+++ b/test/lib/Redeployer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 interface CodeJar {
     function saveCode(bytes memory code) external returns (address);

--- a/test/lib/ReentrantTransfer.sol
+++ b/test/lib/ReentrantTransfer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";

--- a/test/lib/Reverts.sol
+++ b/test/lib/Reverts.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {CodeJar} from "codejar/src/CodeJar.sol";
 

--- a/test/lib/SignatureHelper.sol
+++ b/test/lib/SignatureHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "quark-core/src/QuarkWallet.sol";

--- a/test/lib/TickCounter.sol
+++ b/test/lib/TickCounter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 contract TickCounter {
     uint256 public immutable base;

--- a/test/lib/Transfer.sol
+++ b/test/lib/Transfer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";

--- a/test/lib/VictimERC777.sol
+++ b/test/lib/VictimERC777.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "openzeppelin/token/ERC777/ERC777.sol";
 import "openzeppelin/token/ERC20/ERC20.sol";

--- a/test/lib/Wacky.sol
+++ b/test/lib/Wacky.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 contract WackyBeacon {
     bytes public code;

--- a/test/lib/YulHelper.sol
+++ b/test/lib/YulHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 

--- a/test/quark-core-scripts/ConditionalMulticall.t.sol
+++ b/test/quark-core-scripts/ConditionalMulticall.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-core-scripts/Ethcall.t.sol
+++ b/test/quark-core-scripts/Ethcall.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-core-scripts/Multicall.t.sol
+++ b/test/quark-core-scripts/Multicall.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-core-scripts/Paycall.t.sol
+++ b/test/quark-core-scripts/Paycall.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-core-scripts/Quotecall.t.sol
+++ b/test/quark-core-scripts/Quotecall.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-core-scripts/UniswapFlashLoan.t.sol
+++ b/test/quark-core-scripts/UniswapFlashLoan.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-core-scripts/UniswapFlashSwapExactOut.t.sol
+++ b/test/quark-core-scripts/UniswapFlashSwapExactOut.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-core-scripts/interfaces/IComet.sol
+++ b/test/quark-core-scripts/interfaces/IComet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 interface IComet {
     function getAssetInfo(uint8 i) external view returns (AssetInfo memory);

--- a/test/quark-core-scripts/interfaces/ISwapRouter.sol
+++ b/test/quark-core-scripts/interfaces/ISwapRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 // Router interfaces thats only used in test for swapping
 interface ISwapRouter {

--- a/test/quark-core/Callbacks.t.sol
+++ b/test/quark-core/Callbacks.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/console.sol";
 
@@ -173,33 +173,61 @@ contract CallbacksTest is Test {
         assertEq(counter.number(), 2);
     }
 
-    function testClearCallback() public {
+    function testSimpleCallback() public {
         // gas: do not meter set-up
         vm.pauseGasMetering();
-        bytes32 callbackSlot = aliceWallet.CALLBACK_SLOT();
         bytes memory allowCallbacks = new YulHelper().getCode("AllowCallbacks.sol/AllowCallbacks.json");
 
         (QuarkWallet.QuarkOperation memory op1, bytes32[] memory submissionTokens) = new QuarkOperationHelper()
             .newReplayableOpWithCalldata(
-            aliceWallet, allowCallbacks, abi.encodeWithSignature("allowCallbackFun()"), ScriptType.ScriptSource, 1
+            aliceWallet, allowCallbacks, abi.encodeWithSignature("run()"), ScriptType.ScriptSource, 1
         );
         (uint8 v1, bytes32 r1, bytes32 s1) = new SignatureHelper().signOp(alicePrivateKey, aliceWallet, op1);
-        QuarkWallet.QuarkOperation memory op2 = new QuarkOperationHelper().newBasicOpWithCalldata(
-            aliceWallet, allowCallbacks, abi.encodeWithSignature("clearCallbackFun()"), ScriptType.ScriptSource
-        );
-        op2.nonce = op1.nonce;
-        (uint8 v2, bytes32 r2, bytes32 s2) = new SignatureHelper().signOp(alicePrivateKey, aliceWallet, op2);
-
-        assertEq(vm.load(address(aliceWallet), callbackSlot), bytes32(0));
 
         // gas: meter execute
         vm.resumeGasMetering();
+        bytes memory result = aliceWallet.executeQuarkOperation(op1, v1, r1, s1);
+        uint256 res = abi.decode(result, (uint256));
+        assertEq(res, 202);
+
+        // Can run again
+        result = aliceWallet.executeQuarkOperationWithSubmissionToken(op1, submissionTokens[1], v1, r1, s1);
+        res = abi.decode(result, (uint256));
+        assertEq(res, 204);
+    }
+
+    function testWithoutAllowCallback() public {
+        // gas: do not meter set-up
+        vm.pauseGasMetering();
+        bytes memory allowCallbacks = new YulHelper().getCode("AllowCallbacks.sol/AllowCallbacks.json");
+
+        (QuarkWallet.QuarkOperation memory op1, bytes32[] memory submissionTokens) = new QuarkOperationHelper()
+            .newReplayableOpWithCalldata(
+            aliceWallet, allowCallbacks, abi.encodeWithSignature("runWithoutAllow()"), ScriptType.ScriptSource, 1
+        );
+        (uint8 v1, bytes32 r1, bytes32 s1) = new SignatureHelper().signOp(alicePrivateKey, aliceWallet, op1);
+
+        // gas: meter execute
+        vm.resumeGasMetering();
+        vm.expectRevert(abi.encodeWithSelector(QuarkWallet.NoActiveCallback.selector));
         aliceWallet.executeQuarkOperation(op1, v1, r1, s1);
+    }
 
-        assertNotEq(vm.load(address(aliceWallet), callbackSlot), bytes32(0));
+    function testWithClearedCallback() public {
+        // gas: do not meter set-up
+        vm.pauseGasMetering();
+        bytes memory allowCallbacks = new YulHelper().getCode("AllowCallbacks.sol/AllowCallbacks.json");
 
-        aliceWallet.executeQuarkOperationWithSubmissionToken(op2, submissionTokens[1], v2, r2, s2);
-        assertEq(vm.load(address(aliceWallet), callbackSlot), bytes32(0));
+        (QuarkWallet.QuarkOperation memory op1, bytes32[] memory submissionTokens) = new QuarkOperationHelper()
+            .newReplayableOpWithCalldata(
+            aliceWallet, allowCallbacks, abi.encodeWithSignature("runAllowThenClear()"), ScriptType.ScriptSource, 1
+        );
+        (uint8 v1, bytes32 r1, bytes32 s1) = new SignatureHelper().signOp(alicePrivateKey, aliceWallet, op1);
+
+        // gas: meter execute
+        vm.resumeGasMetering();
+        vm.expectRevert(abi.encodeWithSelector(QuarkWallet.NoActiveCallback.selector));
+        aliceWallet.executeQuarkOperation(op1, v1, r1, s1);
     }
 
     function testRevertsOnCallbackWhenNoActiveCallback() public {

--- a/test/quark-core/Callbacks.t.sol
+++ b/test/quark-core/Callbacks.t.sol
@@ -201,8 +201,7 @@ contract CallbacksTest is Test {
         vm.pauseGasMetering();
         bytes memory allowCallbacks = new YulHelper().getCode("AllowCallbacks.sol/AllowCallbacks.json");
 
-        (QuarkWallet.QuarkOperation memory op1, bytes32[] memory submissionTokens) = new QuarkOperationHelper()
-            .newReplayableOpWithCalldata(
+        (QuarkWallet.QuarkOperation memory op1,) = new QuarkOperationHelper().newReplayableOpWithCalldata(
             aliceWallet, allowCallbacks, abi.encodeWithSignature("runWithoutAllow()"), ScriptType.ScriptSource, 1
         );
         (uint8 v1, bytes32 r1, bytes32 s1) = new SignatureHelper().signOp(alicePrivateKey, aliceWallet, op1);
@@ -218,8 +217,7 @@ contract CallbacksTest is Test {
         vm.pauseGasMetering();
         bytes memory allowCallbacks = new YulHelper().getCode("AllowCallbacks.sol/AllowCallbacks.json");
 
-        (QuarkWallet.QuarkOperation memory op1, bytes32[] memory submissionTokens) = new QuarkOperationHelper()
-            .newReplayableOpWithCalldata(
+        (QuarkWallet.QuarkOperation memory op1,) = new QuarkOperationHelper().newReplayableOpWithCalldata(
             aliceWallet, allowCallbacks, abi.encodeWithSignature("runAllowThenClear()"), ScriptType.ScriptSource, 1
         );
         (uint8 v1, bytes32 r1, bytes32 s1) = new SignatureHelper().signOp(alicePrivateKey, aliceWallet, op1);

--- a/test/quark-core/EIP1271.t.sol
+++ b/test/quark-core/EIP1271.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/StdUtils.sol";

--- a/test/quark-core/EIP712.t.sol
+++ b/test/quark-core/EIP712.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/StdUtils.sol";

--- a/test/quark-core/Executor.t.sol
+++ b/test/quark-core/Executor.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/console.sol";
 

--- a/test/quark-core/Noncer.t.sol
+++ b/test/quark-core/Noncer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-core/QuarkNonceManager.t.sol
+++ b/test/quark-core/QuarkNonceManager.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-core/QuarkWallet.t.sol
+++ b/test/quark-core/QuarkWallet.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-core/QuarkWallet.t.sol
+++ b/test/quark-core/QuarkWallet.t.sol
@@ -28,7 +28,7 @@ import {Incrementer} from "test/lib/Incrementer.sol";
 import {PrecompileCaller} from "test/lib/PrecompileCaller.sol";
 import {MaxCounterScript} from "test/lib/MaxCounterScript.sol";
 import {GetMessageDetails} from "test/lib/GetMessageDetails.sol";
-import {CancelOtherScript} from "test/lib/CancelOtherScript.sol";
+import {CheckNonceScript} from "test/lib/CheckNonceScript.sol";
 
 contract QuarkWalletTest is Test {
     enum ExecutionType {
@@ -37,11 +37,12 @@ contract QuarkWalletTest is Test {
     }
 
     event Ping(uint256);
-    event ExecuteQuarkScript(
+    event QuarkExecution(
         address indexed executor,
         address indexed scriptAddress,
         bytes32 indexed nonce,
         bytes32 submissionToken,
+        bool isReplayable,
         ExecutionType executionType
     );
 
@@ -162,14 +163,24 @@ contract QuarkWalletTest is Test {
         // gas: meter execute
         vm.resumeGasMetering();
         vm.expectEmit(true, true, true, true);
-        emit ExecuteQuarkScript(
-            address(this), scriptAddress, opWithScriptAddress.nonce, opWithScriptAddress.nonce, ExecutionType.Signature
+        emit QuarkExecution(
+            address(this),
+            scriptAddress,
+            opWithScriptAddress.nonce,
+            opWithScriptAddress.nonce,
+            false,
+            ExecutionType.Signature
         );
         aliceWallet.executeQuarkOperation(opWithScriptAddress, v, r, s);
 
         vm.expectEmit(true, true, true, true);
-        emit ExecuteQuarkScript(
-            address(this), scriptAddress, opWithScriptSource.nonce, opWithScriptSource.nonce, ExecutionType.Signature
+        emit QuarkExecution(
+            address(this),
+            scriptAddress,
+            opWithScriptSource.nonce,
+            opWithScriptSource.nonce,
+            false,
+            ExecutionType.Signature
         );
         aliceWallet.executeQuarkOperation(opWithScriptSource, v2, r2, s2);
     }
@@ -193,22 +204,27 @@ contract QuarkWalletTest is Test {
         // gas: meter execute
         vm.resumeGasMetering();
         vm.expectEmit(true, true, true, true);
-        emit ExecuteQuarkScript(
-            address(this), scriptAddress, opWithScriptAddress.nonce, opWithScriptAddress.nonce, ExecutionType.Signature
+        emit QuarkExecution(
+            address(this),
+            scriptAddress,
+            opWithScriptAddress.nonce,
+            opWithScriptAddress.nonce,
+            true,
+            ExecutionType.Signature
         );
         aliceWallet.executeQuarkOperation(opWithScriptAddress, v, r, s);
 
         // second execution
         vm.expectEmit(true, true, true, true);
-        emit ExecuteQuarkScript(
-            address(this), scriptAddress, opWithScriptAddress.nonce, submissionTokens[1], ExecutionType.Signature
+        emit QuarkExecution(
+            address(this), scriptAddress, opWithScriptAddress.nonce, submissionTokens[1], true, ExecutionType.Signature
         );
         aliceWallet.executeQuarkOperationWithSubmissionToken(opWithScriptAddress, submissionTokens[1], v, r, s);
 
         // third execution
         vm.expectEmit(true, true, true, true);
-        emit ExecuteQuarkScript(
-            address(this), scriptAddress, opWithScriptAddress.nonce, submissionTokens[2], ExecutionType.Signature
+        emit QuarkExecution(
+            address(this), scriptAddress, opWithScriptAddress.nonce, submissionTokens[2], true, ExecutionType.Signature
         );
         aliceWallet.executeQuarkOperationWithSubmissionToken(opWithScriptAddress, submissionTokens[2], v, r, s);
     }
@@ -227,7 +243,7 @@ contract QuarkWalletTest is Test {
         // gas: meter execute
         vm.resumeGasMetering();
         vm.expectEmit(true, true, true, true);
-        emit ExecuteQuarkScript(address(aliceAccount), scriptAddress, nonce, nonce, ExecutionType.Direct);
+        emit QuarkExecution(address(aliceAccount), scriptAddress, nonce, nonce, false, ExecutionType.Direct);
         aliceWalletExecutable.executeScript(nonce, scriptAddress, call, new bytes[](0));
     }
 
@@ -251,7 +267,7 @@ contract QuarkWalletTest is Test {
         // gas: meter execute
         vm.resumeGasMetering();
         vm.expectEmit(true, true, true, true);
-        emit ExecuteQuarkScript(address(aliceAccount), scriptAddress, nonce, nonce, ExecutionType.Direct);
+        emit QuarkExecution(address(aliceAccount), scriptAddress, nonce, nonce, false, ExecutionType.Direct);
         aliceWalletExecutable.executeScript(nonce, scriptAddress, call, scriptSources);
 
         assertEq(counter.number(), 1);
@@ -592,8 +608,6 @@ contract QuarkWalletTest is Test {
         (uint8 cancelV, bytes32 cancelR, bytes32 cancelS) =
             new SignatureHelper().signOp(alicePrivateKey, aliceWallet, cancelOtherOp);
         vm.resumeGasMetering();
-        vm.expectEmit(true, true, true, true);
-        emit CancelOtherScript.Nop();
         aliceWallet.executeQuarkOperationWithSubmissionToken(
             cancelOtherOp, submissionTokens[1], cancelV, cancelR, cancelS
         );
@@ -638,16 +652,13 @@ contract QuarkWalletTest is Test {
 
         // can cancel the replayable nonce...
         vm.pauseGasMetering();
-        QuarkWallet.QuarkOperation memory cancelOtherOp =
-            new QuarkOperationHelper().cancelReplayableByNewOp(aliceWallet, op);
+        QuarkWallet.QuarkOperation memory cancelOp = new QuarkOperationHelper().cancelReplayableByNewOp(aliceWallet, op);
         (uint8 cancelV, bytes32 cancelR, bytes32 cancelS) =
-            new SignatureHelper().signOp(alicePrivateKey, aliceWallet, cancelOtherOp);
+            new SignatureHelper().signOp(alicePrivateKey, aliceWallet, cancelOp);
         vm.resumeGasMetering();
         vm.expectEmit(true, true, true, true);
-        emit CancelOtherScript.CancelNonce(op.nonce);
-        aliceWallet.executeQuarkOperationWithSubmissionToken(
-            cancelOtherOp, submissionTokens[1], cancelV, cancelR, cancelS
-        );
+        emit QuarkNonceManager.NonceCanceled(address(aliceWallet), op.nonce);
+        aliceWallet.executeQuarkOperationWithSubmissionToken(cancelOp, submissionTokens[1], cancelV, cancelR, cancelS);
 
         // and now you can no longer replay
         vm.expectRevert(

--- a/test/quark-core/Reverts.t.sol
+++ b/test/quark-core/Reverts.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-core/isValidSignature.t.sol
+++ b/test/quark-core/isValidSignature.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/StdUtils.sol";

--- a/test/quark-core/periphery/BatchExecutor.t.sol
+++ b/test/quark-core/periphery/BatchExecutor.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-factory/QuarkFactory.t.sol
+++ b/test/quark-factory/QuarkFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/quark-proxy/QuarkMinimalProxy.t.sol
+++ b/test/quark-proxy/QuarkMinimalProxy.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/console.sol";
 import {Test} from "forge-std/Test.sol";

--- a/test/quark-proxy/QuarkWalletProxyFactory.t.sol
+++ b/test/quark-proxy/QuarkWalletProxyFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.23;
+pragma solidity 0.8.27;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";


### PR DESCRIPTION
This patch bumps us up to 0.8.27 and cancun and starts using `tstore` and `tload` for transient reads and writes. Note: we still clear values mostly to ensure that post-nested calls the script will see 0 instead of the nested's own value.

Note: I have not taken a stab at understanding `ALLOW_CALLBACKS` and how that should function.