### PR TITLE
Remove `exhausted` from `NonReplayableNonce` error

### DIFF
--- a/src/quark-core/src/QuarkNonceManager.sol
+++ b/src/quark-core/src/QuarkNonceManager.sol
@@ -17,7 +17,7 @@ library QuarkNonceManagerMetadata {
  * @author Compound Labs, Inc.
  */
 contract QuarkNonceManager {
-    error NonReplayableNonce(address wallet, bytes32 nonce, bytes32 submissionToken, bool exhausted);
+    error NonReplayableNonce(address wallet, bytes32 nonce, bytes32 submissionToken);
     error InvalidNonce(address wallet, bytes32 nonce);
     error InvalidSubmissionToken(address wallet, bytes32 nonce, bytes32 submissionToken);
 
@@ -51,7 +51,7 @@ contract QuarkNonceManager {
     function submit(bytes32 nonce, bool isReplayable, bytes32 submissionToken) external {
         bytes32 lastTokenSubmission = submissions[msg.sender][nonce];
         if (lastTokenSubmission == EXHAUSTED) {
-            revert NonReplayableNonce(msg.sender, nonce, submissionToken, true);
+            revert NonReplayableNonce(msg.sender, nonce, submissionToken);
         }
         // Defense-in-depth check for `nonce != FREE` and `nonce != EXHAUSTED`
         if (nonce == FREE || nonce == EXHAUSTED) {

--- a/test/ReplayableTransactions.t.sol
+++ b/test/ReplayableTransactions.t.sol
@@ -207,14 +207,14 @@ contract ReplayableTransactionsTest is Test {
         vm.warp(block.timestamp + purchaseInterval);
         vm.expectRevert(
             abi.encodeWithSelector(
-                QuarkNonceManager.NonReplayableNonce.selector, address(aliceWallet), op.nonce, submissionTokens[1], true
+                QuarkNonceManager.NonReplayableNonce.selector, address(aliceWallet), op.nonce, submissionTokens[1]
             )
         );
         aliceWallet.executeQuarkOperationWithSubmissionToken(op, submissionTokens[1], v1, r1, s1);
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                QuarkNonceManager.NonReplayableNonce.selector, address(aliceWallet), op.nonce, submissionTokens[2], true
+                QuarkNonceManager.NonReplayableNonce.selector, address(aliceWallet), op.nonce, submissionTokens[2]
             )
         );
         aliceWallet.executeQuarkOperationWithSubmissionToken(op, submissionTokens[2], v1, r1, s1);

--- a/test/quark-core/EIP712.t.sol
+++ b/test/quark-core/EIP712.t.sol
@@ -231,9 +231,7 @@ contract EIP712Test is Test {
 
         // submitter tries to reuse the same signature twice, for a non-replayable operation
         vm.expectRevert(
-            abi.encodeWithSelector(
-                QuarkNonceManager.NonReplayableNonce.selector, address(wallet), op.nonce, op.nonce, true
-            )
+            abi.encodeWithSelector(QuarkNonceManager.NonReplayableNonce.selector, address(wallet), op.nonce, op.nonce)
         );
         wallet.executeQuarkOperation(op, v, r, s);
     }

--- a/test/quark-core/QuarkNonceManager.t.sol
+++ b/test/quark-core/QuarkNonceManager.t.sol
@@ -68,11 +68,7 @@ contract QuarkNonceManagerTest is Test {
         for (uint256 i = 1; i <= 20; i++) {
             vm.expectRevert(
                 abi.encodeWithSelector(
-                    QuarkNonceManager.NonReplayableNonce.selector,
-                    address(this),
-                    bytes32(i),
-                    bytes32(type(uint256).max),
-                    true
+                    QuarkNonceManager.NonReplayableNonce.selector, address(this), bytes32(i), bytes32(type(uint256).max)
                 )
             );
             nonceManager.submit(bytes32(i), false, EXHAUSTED_TOKEN);
@@ -85,12 +81,12 @@ contract QuarkNonceManagerTest is Test {
         nonceManager.submit(nonce, false, nonce);
 
         vm.expectRevert(
-            abi.encodeWithSelector(QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, nonce, true)
+            abi.encodeWithSelector(QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, nonce)
         );
         nonceManager.submit(nonce, false, nonce);
 
         vm.expectRevert(
-            abi.encodeWithSelector(QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, EXHAUSTED, true)
+            abi.encodeWithSelector(QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, EXHAUSTED)
         );
         nonceManager.submit(nonce, false, EXHAUSTED);
     }
@@ -130,9 +126,7 @@ contract QuarkNonceManagerTest is Test {
         assertEq(nonceManager.submissions(address(this), nonce), EXHAUSTED_TOKEN);
 
         vm.expectRevert(
-            abi.encodeWithSelector(
-                QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, nonceSecret, true
-            )
+            abi.encodeWithSelector(QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, nonceSecret)
         );
         nonceManager.submit(nonce, true, nonceSecret);
     }
@@ -178,15 +172,11 @@ contract QuarkNonceManagerTest is Test {
         assertEq(nonceManager.submissions(address(this), nonce), EXHAUSTED_TOKEN);
 
         vm.expectRevert(
-            abi.encodeWithSelector(
-                QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, FREE_TOKEN, true
-            )
+            abi.encodeWithSelector(QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, FREE_TOKEN)
         );
         nonceManager.submit(nonce, false, FREE_TOKEN);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, EXHAUSTED_TOKEN, true
-            )
+            abi.encodeWithSelector(QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, EXHAUSTED_TOKEN)
         );
         nonceManager.submit(nonce, false, EXHAUSTED_TOKEN);
     }
@@ -368,38 +358,32 @@ contract QuarkNonceManagerTest is Test {
         assertEq(nonceManager.submissions(address(this), nonce), EXHAUSTED_TOKEN);
 
         vm.expectRevert(
-            abi.encodeWithSelector(QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, nonce, true)
+            abi.encodeWithSelector(QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, nonce)
         );
         nonceManager.submit(nonce, true, nonce);
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, submissionToken2, true
+                QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, submissionToken2
             )
         );
         nonceManager.submit(nonce, true, submissionToken2);
         vm.expectRevert(
             abi.encodeWithSelector(
-                QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, submissionToken1, true
+                QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, submissionToken1
             )
         );
         nonceManager.submit(nonce, true, submissionToken1);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, nonceSecret, true
-            )
+            abi.encodeWithSelector(QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, nonceSecret)
         );
         nonceManager.submit(nonce, true, nonceSecret);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, EXHAUSTED_TOKEN, true
-            )
+            abi.encodeWithSelector(QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, EXHAUSTED_TOKEN)
         );
         nonceManager.submit(nonce, true, EXHAUSTED_TOKEN);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, FREE_TOKEN, true
-            )
+            abi.encodeWithSelector(QuarkNonceManager.NonReplayableNonce.selector, address(this), nonce, FREE_TOKEN)
         );
         nonceManager.submit(nonce, true, FREE_TOKEN);
     }
@@ -416,7 +400,7 @@ contract QuarkNonceManagerTest is Test {
         // nonce 1 can be set manually
         vm.prank(address(0x123));
         vm.expectRevert(
-            abi.encodeWithSelector(QuarkNonceManager.NonReplayableNonce.selector, address(0x123), nonce, nonce, true)
+            abi.encodeWithSelector(QuarkNonceManager.NonReplayableNonce.selector, address(0x123), nonce, nonce)
         );
         nonceManager.submit(nonce, false, nonce);
         assertEq(nonceManager.submissions(address(0x123), nonce), nonceManager.EXHAUSTED());

--- a/test/quark-core/QuarkWallet.t.sol
+++ b/test/quark-core/QuarkWallet.t.sol
@@ -276,7 +276,7 @@ contract QuarkWalletTest is Test {
         // Not sure why this revert isn't showing up-- it's reverting, nonetheless.
         // vm.expectRevert(
         //     abi.encodeWithSelector(
-        //         QuarkNonceManager.NonReplayableNonce.selector, address(aliceWalletExecutable), nonce, nonce, true
+        //         QuarkNonceManager.NonReplayableNonce.selector, address(aliceWalletExecutable), nonce, nonce
         //     )
         // );
         aliceWalletExecutable.executeScript(nonce, scriptAddress, call, scriptSources);
@@ -331,7 +331,7 @@ contract QuarkWalletTest is Test {
         // Check it is no longer runnable
         vm.expectRevert(
             abi.encodeWithSelector(
-                QuarkNonceManager.NonReplayableNonce.selector, address(aliceWallet), op.nonce, op.nonce, true
+                QuarkNonceManager.NonReplayableNonce.selector, address(aliceWallet), op.nonce, op.nonce
             )
         );
         aliceWallet.executeQuarkOperationWithSubmissionToken(op, op.nonce, v, r, s);
@@ -619,7 +619,7 @@ contract QuarkWalletTest is Test {
         // and now you can no longer replay
         vm.expectRevert(
             abi.encodeWithSelector(
-                QuarkNonceManager.NonReplayableNonce.selector, address(aliceWallet), op.nonce, submissionTokens[1], true
+                QuarkNonceManager.NonReplayableNonce.selector, address(aliceWallet), op.nonce, submissionTokens[1]
             )
         );
         aliceWallet.executeQuarkOperationWithSubmissionToken(op, submissionTokens[1], v, r, s);
@@ -667,7 +667,7 @@ contract QuarkWalletTest is Test {
         // and now you can no longer replay
         vm.expectRevert(
             abi.encodeWithSelector(
-                QuarkNonceManager.NonReplayableNonce.selector, address(aliceWallet), op.nonce, submissionTokens[1], true
+                QuarkNonceManager.NonReplayableNonce.selector, address(aliceWallet), op.nonce, submissionTokens[1]
             )
         );
         aliceWallet.executeQuarkOperationWithSubmissionToken(op, submissionTokens[1], v, r, s);
@@ -937,7 +937,7 @@ contract QuarkWalletTest is Test {
         // call again using the same operation
         vm.expectRevert(
             abi.encodeWithSelector(
-                QuarkNonceManager.NonReplayableNonce.selector, address(aliceWallet), op1.nonce, op1.nonce, true
+                QuarkNonceManager.NonReplayableNonce.selector, address(aliceWallet), op1.nonce, op1.nonce
             )
         );
         aliceWallet.executeMultiQuarkOperation(op1, opDigests, v, r, s);
@@ -1110,14 +1110,12 @@ contract QuarkWalletTest is Test {
         // test all tokens do not replay now for op1, which is non-replayable
         vm.expectRevert(
             abi.encodeWithSelector(
-                QuarkNonceManager.NonReplayableNonce.selector, aliceWallet, op1.nonce, EXHAUSTED_TOKEN, true
+                QuarkNonceManager.NonReplayableNonce.selector, aliceWallet, op1.nonce, EXHAUSTED_TOKEN
             )
         );
         aliceWallet.executeMultiQuarkOperationWithSubmissionToken(op1, EXHAUSTED_TOKEN, opDigests, v, r, s);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                QuarkNonceManager.NonReplayableNonce.selector, aliceWallet, op1.nonce, op1.nonce, true
-            )
+            abi.encodeWithSelector(QuarkNonceManager.NonReplayableNonce.selector, aliceWallet, op1.nonce, op1.nonce)
         );
         aliceWallet.executeMultiQuarkOperationWithSubmissionToken(op1, op1.nonce, opDigests, v, r, s);
 


### PR DESCRIPTION
This field is unnecessary since it is always set to `true`.