### PR TITLE
Emit NonceSubmitted when a nonce is canceled

### DIFF
--- a/src/quark-core/src/QuarkNonceManager.sol
+++ b/src/quark-core/src/QuarkNonceManager.sol
@@ -22,7 +22,6 @@ contract QuarkNonceManager {
     error InvalidSubmissionToken(address wallet, bytes32 nonce, bytes32 submissionToken);
 
     event NonceSubmitted(address wallet, bytes32 nonce, bytes32 submissionToken);
-    event NonceCanceled(address wallet, bytes32 nonce);
 
     /// @notice Represents the unclaimed bytes32 value.
     bytes32 public constant FREE = QuarkNonceManagerMetadata.FREE;
@@ -39,7 +38,7 @@ contract QuarkNonceManager {
      */
     function cancel(bytes32 nonce) external {
         submissions[msg.sender][nonce] = EXHAUSTED;
-        emit NonceCanceled(msg.sender, nonce);
+        emit NonceSubmitted(msg.sender, nonce, EXHAUSTED);
     }
 
     /**

--- a/test/quark-core/QuarkWallet.t.sol
+++ b/test/quark-core/QuarkWallet.t.sol
@@ -661,7 +661,7 @@ contract QuarkWalletTest is Test {
             new SignatureHelper().signOp(alicePrivateKey, aliceWallet, cancelOp);
         vm.resumeGasMetering();
         vm.expectEmit(true, true, true, true);
-        emit QuarkNonceManager.NonceCanceled(address(aliceWallet), op.nonce);
+        emit QuarkNonceManager.NonceSubmitted(address(aliceWallet), op.nonce, bytes32(type(uint256).max));
         aliceWallet.executeQuarkOperationWithSubmissionToken(cancelOp, submissionTokens[1], cancelV, cancelR, cancelS);
 
         // and now you can no longer replay


### PR DESCRIPTION
This improves the consistency of events in `QuarkNonceManager`. A nonce could be canceled either via `cancel` or `submit`, and the two paths currently will emit different events. This change ensures that cancelling using either approach will always emit the same events. 