### PR TITLE
Set callback slot to 0 before executing script

### DIFF
--- a/src/quark-core/src/QuarkWallet.sol
+++ b/src/quark-core/src/QuarkWallet.sol
@@ -503,6 +503,9 @@ contract QuarkWallet is IERC1271 {
             // Transiently store the active submission token
             tstore(activeSubmissionTokenSlot, submissionToken)
 
+            // Transiently set the callback slot to 0
+            tstore(callbackSlot, 0)
+
             // Note: CALLCODE is used to set the QuarkWallet as the `msg.sender`
             success :=
                 callcode(gas(), scriptAddress, /* value */ 0, add(scriptCalldata, 0x20), scriptCalldataLen, 0x0, 0)

--- a/test/lib/GetCallbackDetails.sol
+++ b/test/lib/GetCallbackDetails.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.27;
+
+import {QuarkWalletMetadata} from "quark-core/src/QuarkWallet.sol";
+import {QuarkScript} from "quark-core/src/QuarkScript.sol";
+
+contract GetCallbackDetails is QuarkScript {
+    function getCallbackAddress() public returns (address) {
+        bytes32 callbackSlot = QuarkWalletMetadata.CALLBACK_SLOT;
+        address callbackAddress;
+        assembly {
+            callbackAddress := tload(callbackSlot)
+        }
+        return callbackAddress;
+    }
+}

--- a/test/lib/GetCallbackDetails.sol
+++ b/test/lib/GetCallbackDetails.sol
@@ -5,7 +5,7 @@ import {QuarkWalletMetadata} from "quark-core/src/QuarkWallet.sol";
 import {QuarkScript} from "quark-core/src/QuarkScript.sol";
 
 contract GetCallbackDetails is QuarkScript {
-    function getCallbackAddress() public returns (address) {
+    function getCallbackAddress() public view returns (address) {
         bytes32 callbackSlot = QuarkWalletMetadata.CALLBACK_SLOT;
         address callbackAddress;
         assembly {


### PR DESCRIPTION
We need to set the callback slot to 0 before executing a script to ensure that nested operations don't inherit the callback value of the parent operation.