### PR TITLE
CS5.1 - Disallow callbacks at the start of a script's callback function

### DIFF
--- a/src/quark-core-scripts/src/UniswapFlashLoan.sol
+++ b/src/quark-core-scripts/src/UniswapFlashLoan.sol
@@ -70,6 +70,7 @@ contract UniswapFlashLoan is IUniswapV3FlashCallback, QuarkScript {
      * @param data FlashLoanCallbackPayload encoded to bytes passed from IUniswapV3Pool.flash(); contains scripts info to execute before repaying the flash loan
      */
     function uniswapV3FlashCallback(uint256 fee0, uint256 fee1, bytes calldata data) external {
+        disallowCallback();
         FlashLoanCallbackPayload memory input = abi.decode(data, (FlashLoanCallbackPayload));
         IUniswapV3Pool pool =
             IUniswapV3Pool(PoolAddress.computeAddress(UniswapFactoryAddress.getAddress(), input.poolKey));

--- a/src/quark-core-scripts/src/UniswapFlashLoan.sol
+++ b/src/quark-core-scripts/src/UniswapFlashLoan.sol
@@ -71,6 +71,7 @@ contract UniswapFlashLoan is IUniswapV3FlashCallback, QuarkScript {
      */
     function uniswapV3FlashCallback(uint256 fee0, uint256 fee1, bytes calldata data) external {
         disallowCallback();
+
         FlashLoanCallbackPayload memory input = abi.decode(data, (FlashLoanCallbackPayload));
         IUniswapV3Pool pool =
             IUniswapV3Pool(PoolAddress.computeAddress(UniswapFactoryAddress.getAddress(), input.poolKey));

--- a/src/quark-core-scripts/src/UniswapFlashSwapExactOut.sol
+++ b/src/quark-core-scripts/src/UniswapFlashSwapExactOut.sol
@@ -74,6 +74,8 @@ contract UniswapFlashSwapExactOut is IUniswapV3SwapCallback, QuarkScript {
      * @param data FlashSwap encoded to bytes passed from UniswapV3Pool.swap(); contains script info to execute (possibly with checks) before returning the owed amount
      */
     function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata data) external {
+        disallowCallback();
+
         FlashSwapExactOutInput memory input = abi.decode(data, (FlashSwapExactOutInput));
         IUniswapV3Pool pool =
             IUniswapV3Pool(PoolAddress.computeAddress(UniswapFactoryAddress.getAddress(), input.poolKey));

--- a/src/quark-core/src/QuarkScript.sol
+++ b/src/quark-core/src/QuarkScript.sol
@@ -74,7 +74,12 @@ abstract contract QuarkScript {
         return QuarkNonceManager(IQuarkWallet(address(this)).nonceManager());
     }
 
-    /// @notice Enables callbacks to the wallet
+    /**
+     * @notice Enables callbacks to the wallet
+     * @dev Scripts should remember to disallow callbacks at the start of the callback function,
+     *      otherwise external contracts in the same Quark operation can continue to call into
+     *      the wallet.
+     */
     function allowCallback() internal {
         bytes32 callbackSlot = QuarkWalletMetadata.CALLBACK_SLOT;
         bytes32 activeScriptSlot = QuarkWalletMetadata.ACTIVE_SCRIPT_SLOT;
@@ -85,7 +90,7 @@ abstract contract QuarkScript {
     }
 
     /// @notice Disables callbacks to the wallet
-    function clearCallback() internal {
+    function disallowCallback() internal {
         bytes32 callbackSlot = QuarkWalletMetadata.CALLBACK_SLOT;
         assembly {
             tstore(callbackSlot, 0)

--- a/test/lib/AllowCallbacks.sol
+++ b/test/lib/AllowCallbacks.sol
@@ -22,7 +22,7 @@ contract AllowCallbacks is QuarkScript {
 
     function runAllowThenClear() public returns (uint256) {
         allowCallback();
-        clearCallback();
+        disallowCallback();
         return new Comebacker().comeback() * 2;
     }
 

--- a/test/quark-core-scripts/UniswapFlashLoan.t.sol
+++ b/test/quark-core-scripts/UniswapFlashLoan.t.sol
@@ -187,6 +187,53 @@ contract UniswapFlashLoanTest is Test {
         assertEq(IComet(comet).borrowBalanceOf(address(wallet)), 1000e6);
     }
 
+    function testRevertsForSecondCallback() public {
+        vm.pauseGasMetering();
+        QuarkWallet wallet = QuarkWallet(factory.create(alice, address(0)));
+
+        address[] memory callContracts = new address[](1);
+        bytes[] memory callDatas = new bytes[](1);
+
+        // Call into the wallet and try to execute the fallback function again using the callback mechanism
+        callContracts[0] = address(wallet);
+        callDatas[0] = abi.encodeWithSelector(
+            Ethcall.run.selector,
+            address(wallet),
+            abi.encodeCall(UniswapFlashLoan.uniswapV3FlashCallback, (100, 500, bytes(""))),
+            0
+        );
+
+        QuarkWallet.QuarkOperation memory op = new QuarkOperationHelper().newBasicOpWithCalldata(
+            wallet,
+            uniswapFlashLoan,
+            abi.encodeWithSelector(
+                UniswapFlashLoan.run.selector,
+                UniswapFlashLoan.UniswapFlashLoanPayload({
+                    token0: USDC,
+                    token1: DAI,
+                    fee: 100,
+                    amount0: 1000e6,
+                    amount1: 0,
+                    callContract: multicallAddress,
+                    callData: abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas)
+                })
+            ),
+            ScriptType.ScriptAddress
+        );
+        (uint8 v, bytes32 r, bytes32 s) = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
+
+        vm.resumeGasMetering();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Multicall.MulticallError.selector,
+                0,
+                callContracts[0],
+                abi.encodeWithSelector(QuarkWallet.NoActiveCallback.selector)
+            )
+        );
+        wallet.executeQuarkOperation(op, v, r, s);
+    }
+
     function testRevertsForInvalidCaller() public {
         vm.pauseGasMetering();
         QuarkWallet wallet = QuarkWallet(factory.create(alice, address(0)));


### PR DESCRIPTION
This PR establishes the pattern that Quark scripts using callbacks should disallow callbacks at the start of their callback function. Otherwise, any external contract that is called in the same Quark Operation context can call back into the Quark wallet and potentially execute malicious code in the context of the wallet.